### PR TITLE
Remove std::ignore from partitioner

### DIFF
--- a/src/Cajita_UniformDimPartitioner.cpp
+++ b/src/Cajita_UniformDimPartitioner.cpp
@@ -16,10 +16,8 @@ namespace Cajita
 //---------------------------------------------------------------------------//
 std::vector<int> UniformDimPartitioner::ranksPerDimension(
     MPI_Comm comm,
-    const std::vector<int>& global_cells_per_dim ) const
+    const std::vector<int>& ) const
 {
-    std::ignore = global_cells_per_dim;
-
     int comm_size;
     MPI_Comm_size( comm, &comm_size );
 


### PR DESCRIPTION
Per #1 the missing `<tuple>` header include was causing some compilers to fail when encountering `std::ignore`. This code changes the implementation to not name the variable in the interface and therefore `std::ignore` is not needed.

Closes #1 