### PR TITLE
Adding optional halo width to shared index space and halo communication

### DIFF
--- a/src/Cajita_Array.hpp
+++ b/src/Cajita_Array.hpp
@@ -67,16 +67,20 @@ class ArrayLayout
     }
 
     // Get the local index space of the array elements we shared with the
-    // given neighbor in the given decomposition.
+    // given neighbor in the given decomposition. Optionally provide a halo
+    // width for the shared space. This halo width must be less than or equal
+    // to the halo width of the block. The default behavior is to use the halo
+    // width of the block.
     template <class DecompositionTag>
     IndexSpace<4> sharedIndexSpace( DecompositionTag decomposition_tag,
                                     const int off_i, const int off_j,
-                                    const int off_k ) const
+                                    const int off_k,
+                                    const int halo_width = -1 ) const
     {
-        return appendDimension( _block->sharedIndexSpace( decomposition_tag,
-                                                          EntityType(), off_i,
-                                                          off_j, off_k ),
-                                _dofs_per_entity );
+        return appendDimension(
+            _block->sharedIndexSpace( decomposition_tag, EntityType(), off_i,
+                                      off_j, off_k, halo_width ),
+            _dofs_per_entity );
     }
 
   private:

--- a/src/Cajita_Block.hpp
+++ b/src/Cajita_Block.hpp
@@ -65,11 +65,15 @@ class Block
     IndexSpace<3> indexSpace( DecompositionTag, EntityType, IndexType ) const;
 
     // Given a relative set of indices of a neighbor get the set of local
-    // entity indices shared with that neighbor in the given decomposition.
+    // entity indices shared with that neighbor in the given
+    // decomposition. Optionally provide a halo width for the shared
+    // space. This halo width must be less than or equal to the halo width of
+    // the block. The default behavior is to use the halo width of the block.
     template <class DecompositionTag, class EntityType>
     IndexSpace<3> sharedIndexSpace( DecompositionTag, EntityType,
                                     const int off_i, const int off_j,
-                                    const int off_k ) const;
+                                    const int off_k,
+                                    const int halo_width = -1 ) const;
 
   private:
     // Get the global index space of the block.
@@ -77,12 +81,6 @@ class Block
     IndexSpace<3> globalIndexSpace( Own, EntityType ) const;
     template <class EntityType>
     IndexSpace<3> globalIndexSpace( Ghost, EntityType ) const;
-
-    // Get the ghosted shared index space of the block.
-    template <class EntityType>
-    IndexSpace<3> ghostedSharedIndexSpace( EntityType, const int off_i,
-                                           const int off_j,
-                                           const int off_k ) const;
 
     // Get the face index space of the block.
     template <int Dir>
@@ -98,12 +96,12 @@ class Block
     // face indices shared with that neighbor in the given decomposition.
     template <int Dir>
     IndexSpace<3> faceSharedIndexSpace( Own, Face<Dir>, const int off_,
-                                        const int off_j,
-                                        const int off_k ) const;
+                                        const int off_j, const int off_k,
+                                        const int halo_width ) const;
     template <int Dir>
     IndexSpace<3> faceSharedIndexSpace( Ghost, Face<Dir>, const int off_i,
-                                        const int off_j,
-                                        const int off_k ) const;
+                                        const int off_j, const int off_k,
+                                        const int halo_width ) const;
 
   private:
     std::shared_ptr<GlobalGrid> _global_grid;

--- a/src/Cajita_Halo.hpp
+++ b/src/Cajita_Halo.hpp
@@ -387,9 +387,10 @@ class Halo
 */
 template <class Scalar, class Device, class EntityType>
 std::shared_ptr<Halo<Scalar, Device>>
-createHalo( const ArrayLayout<EntityType> &layout, const HaloPattern &pattern )
+createHalo( const ArrayLayout<EntityType> &layout, const HaloPattern &pattern,
+            const int width = -1 )
 {
-    return std::make_shared<Halo<Scalar, Device>>( layout, pattern );
+    return std::make_shared<Halo<Scalar, Device>>( layout, pattern, width );
 }
 
 //---------------------------------------------------------------------------//
@@ -406,12 +407,12 @@ std::shared_ptr<
     Halo<typename Array<Scalar, EntityType, Params...>::value_type,
          typename Array<Scalar, EntityType, Params...>::device_type>>
 createHalo( const Array<Scalar, EntityType, Params...> &array,
-            const HaloPattern &pattern )
+            const HaloPattern &pattern, const int width = -1 )
 {
     return std::make_shared<
         Halo<typename Array<Scalar, EntityType, Params...>::value_type,
              typename Array<Scalar, EntityType, Params...>::device_type>>(
-        *( array.layout() ), pattern );
+        *( array.layout() ), pattern, width );
 }
 
 //---------------------------------------------------------------------------//

--- a/src/Cajita_Halo.hpp
+++ b/src/Cajita_Halo.hpp
@@ -91,9 +91,13 @@ class Halo
     /*!
       \brief Constructor.
       \param layout The array layout to build the halo for.
+      \param pattern The halo pattern to use for halo communication
+      \param width An option halo cell width. The default is to use the entire
+      halo width of the block.
     */
     template <class ArrayLayout_t>
-    Halo( const ArrayLayout_t &layout, const HaloPattern &pattern )
+    Halo( const ArrayLayout_t &layout, const HaloPattern &pattern,
+          const int width = -1 )
         : _comm( layout.block()->globalGrid().comm() )
     {
         // Function to get the local id of the neighbor.
@@ -149,7 +153,7 @@ class Halo
                 // Get the owned index space we share with this
                 // neighbor.
                 _owned_spaces.push_back(
-                    layout.sharedIndexSpace( Own(), i, j, k ) );
+                    layout.sharedIndexSpace( Own(), i, j, k, width ) );
 
                 // Create the buffer of data we own that we share
                 // with this neighbor.
@@ -159,7 +163,7 @@ class Halo
                 // Get the ghosted index space we share with this
                 // neighbor.
                 _ghosted_spaces.push_back(
-                    layout.sharedIndexSpace( Ghost(), i, j, k ) );
+                    layout.sharedIndexSpace( Ghost(), i, j, k, width ) );
 
                 // Create the buffer of ghost data that is owned
                 // by our neighbor

--- a/unit_test/tstBlock.hpp
+++ b/unit_test/tstBlock.hpp
@@ -208,6 +208,53 @@ void periodicTest()
     EXPECT_EQ( owned_shared_cell_space.max(Dim::K),
                owned_cell_space.min(Dim::K) + halo_width );
 
+    // Check owned shared cell spaces again but this time with a specified
+    // halo width.
+    owned_shared_cell_space =
+        grid_block->sharedIndexSpace( Own(), Cell(), -1, 0, 1, 1 );
+    EXPECT_EQ( owned_shared_cell_space.min(Dim::I),
+               owned_cell_space.min(Dim::I) );
+    EXPECT_EQ( owned_shared_cell_space.max(Dim::I),
+               owned_cell_space.min(Dim::I) + 1 );
+    EXPECT_EQ( owned_shared_cell_space.min(Dim::J),
+               owned_cell_space.min(Dim::J) );
+    EXPECT_EQ( owned_shared_cell_space.max(Dim::J),
+               owned_cell_space.max(Dim::J) );
+    EXPECT_EQ( owned_shared_cell_space.min(Dim::K),
+               owned_cell_space.max(Dim::K) - 1 );
+    EXPECT_EQ( owned_shared_cell_space.max(Dim::K),
+               owned_cell_space.max(Dim::K) );
+
+    owned_shared_cell_space =
+        grid_block->sharedIndexSpace( Own(), Cell(), 1, -1, 0, 1 );
+    EXPECT_EQ( owned_shared_cell_space.min(Dim::I),
+               owned_cell_space.max(Dim::I) - 1 );
+    EXPECT_EQ( owned_shared_cell_space.max(Dim::I),
+               owned_cell_space.max(Dim::I) );
+    EXPECT_EQ( owned_shared_cell_space.min(Dim::J),
+               owned_cell_space.min(Dim::J) );
+    EXPECT_EQ( owned_shared_cell_space.max(Dim::J),
+               owned_cell_space.min(Dim::J) + 1 );
+    EXPECT_EQ( owned_shared_cell_space.min(Dim::K),
+               owned_cell_space.min(Dim::K) );
+    EXPECT_EQ( owned_shared_cell_space.max(Dim::K),
+               owned_cell_space.max(Dim::K) );
+
+    owned_shared_cell_space =
+        grid_block->sharedIndexSpace( Own(), Cell(), 0, 1, -1, 1 );
+    EXPECT_EQ( owned_shared_cell_space.min(Dim::I),
+               owned_cell_space.min(Dim::I) );
+    EXPECT_EQ( owned_shared_cell_space.max(Dim::I),
+               owned_cell_space.max(Dim::I) );
+    EXPECT_EQ( owned_shared_cell_space.min(Dim::J),
+               owned_cell_space.max(Dim::J) - 1 );
+    EXPECT_EQ( owned_shared_cell_space.max(Dim::J),
+               owned_cell_space.max(Dim::J) );
+    EXPECT_EQ( owned_shared_cell_space.min(Dim::K),
+               owned_cell_space.min(Dim::K) );
+    EXPECT_EQ( owned_shared_cell_space.max(Dim::K),
+               owned_cell_space.min(Dim::K) + 1 );
+
     // Check the cells are ghosts that our neighbors own. Cover enough of the
     // neighbors that we know the bounds are correct in each dimension. The
     // three variations here cover all of the cases.
@@ -253,6 +300,53 @@ void periodicTest()
                owned_cell_space.max(Dim::J) + halo_width );
     EXPECT_EQ( ghosted_shared_cell_space.min(Dim::K),
                0 );
+    EXPECT_EQ( ghosted_shared_cell_space.max(Dim::K),
+               halo_width );
+
+    // Check the ghosted shared cell spaces again but this time with a
+    // specified halo width.
+    ghosted_shared_cell_space =
+        grid_block->sharedIndexSpace( Ghost(), Cell(), -1, 0, 1, 1 );
+    EXPECT_EQ( ghosted_shared_cell_space.min(Dim::I),
+               halo_width - 1 );
+    EXPECT_EQ( ghosted_shared_cell_space.max(Dim::I),
+               halo_width );
+    EXPECT_EQ( ghosted_shared_cell_space.min(Dim::J),
+               owned_cell_space.min(Dim::J) );
+    EXPECT_EQ( ghosted_shared_cell_space.max(Dim::J),
+               owned_cell_space.max(Dim::J) );
+    EXPECT_EQ( ghosted_shared_cell_space.min(Dim::K),
+               owned_cell_space.max(Dim::K) );
+    EXPECT_EQ( ghosted_shared_cell_space.max(Dim::K),
+               owned_cell_space.max(Dim::K) + 1 );
+
+    ghosted_shared_cell_space =
+        grid_block->sharedIndexSpace( Ghost(), Cell(), 1, -1, 0, 1 );
+    EXPECT_EQ( ghosted_shared_cell_space.min(Dim::I),
+               owned_cell_space.max(Dim::I) );
+    EXPECT_EQ( ghosted_shared_cell_space.max(Dim::I),
+               owned_cell_space.max(Dim::I) + 1 );
+    EXPECT_EQ( ghosted_shared_cell_space.min(Dim::J),
+               halo_width - 1 );
+    EXPECT_EQ( ghosted_shared_cell_space.max(Dim::J),
+               halo_width );
+    EXPECT_EQ( ghosted_shared_cell_space.min(Dim::K),
+               owned_cell_space.min(Dim::K) );
+    EXPECT_EQ( ghosted_shared_cell_space.max(Dim::K),
+               owned_cell_space.max(Dim::K) );
+
+    ghosted_shared_cell_space =
+        grid_block->sharedIndexSpace( Ghost(), Cell(), 0, 1, -1, 1 );
+    EXPECT_EQ( ghosted_shared_cell_space.min(Dim::I),
+               owned_cell_space.min(Dim::I) );
+    EXPECT_EQ( ghosted_shared_cell_space.max(Dim::I),
+               owned_cell_space.max(Dim::I) );
+    EXPECT_EQ( ghosted_shared_cell_space.min(Dim::J),
+               owned_cell_space.max(Dim::J) );
+    EXPECT_EQ( ghosted_shared_cell_space.max(Dim::J),
+               owned_cell_space.max(Dim::J) + 1 );
+    EXPECT_EQ( ghosted_shared_cell_space.min(Dim::K),
+               halo_width - 1 );
     EXPECT_EQ( ghosted_shared_cell_space.max(Dim::K),
                halo_width );
 
@@ -391,6 +485,53 @@ void periodicTest()
     EXPECT_EQ( owned_shared_node_space.max(Dim::K),
                owned_node_space.min(Dim::K) + halo_width + 1 );
 
+    // Check the owned shared node spaces again but this time with a specified
+    // halo width.
+    owned_shared_node_space =
+        grid_block->sharedIndexSpace( Own(), Node(), -1, 0, 1, 1 );
+    EXPECT_EQ( owned_shared_node_space.min(Dim::I),
+               owned_node_space.min(Dim::I) );
+    EXPECT_EQ( owned_shared_node_space.max(Dim::I),
+               owned_node_space.min(Dim::I) + 2 );
+    EXPECT_EQ( owned_shared_node_space.min(Dim::J),
+               owned_node_space.min(Dim::J) );
+    EXPECT_EQ( owned_shared_node_space.max(Dim::J),
+               owned_node_space.max(Dim::J) );
+    EXPECT_EQ( owned_shared_node_space.min(Dim::K),
+               owned_node_space.max(Dim::K) - 1 );
+    EXPECT_EQ( owned_shared_node_space.max(Dim::K),
+               owned_node_space.max(Dim::K) );
+
+    owned_shared_node_space =
+        grid_block->sharedIndexSpace( Own(), Node(), 1, -1, 0, 1 );
+    EXPECT_EQ( owned_shared_node_space.min(Dim::I),
+               owned_node_space.max(Dim::I) - 1 );
+    EXPECT_EQ( owned_shared_node_space.max(Dim::I),
+               owned_node_space.max(Dim::I) );
+    EXPECT_EQ( owned_shared_node_space.min(Dim::J),
+               owned_node_space.min(Dim::J) );
+    EXPECT_EQ( owned_shared_node_space.max(Dim::J),
+               owned_node_space.min(Dim::J) + 2 );
+    EXPECT_EQ( owned_shared_node_space.min(Dim::K),
+               owned_node_space.min(Dim::K) );
+    EXPECT_EQ( owned_shared_node_space.max(Dim::K),
+               owned_node_space.max(Dim::K) );
+
+    owned_shared_node_space =
+        grid_block->sharedIndexSpace( Own(), Node(), 0, 1, -1, 1 );
+    EXPECT_EQ( owned_shared_node_space.min(Dim::I),
+               owned_node_space.min(Dim::I) );
+    EXPECT_EQ( owned_shared_node_space.max(Dim::I),
+               owned_node_space.max(Dim::I) );
+    EXPECT_EQ( owned_shared_node_space.min(Dim::J),
+               owned_node_space.max(Dim::J) - 1 );
+    EXPECT_EQ( owned_shared_node_space.max(Dim::J),
+               owned_node_space.max(Dim::J) );
+    EXPECT_EQ( owned_shared_node_space.min(Dim::K),
+               owned_node_space.min(Dim::K) );
+    EXPECT_EQ( owned_shared_node_space.max(Dim::K),
+               owned_node_space.min(Dim::K) + 2 );
+
     // Check the nodes are ghosts that our neighbors own. Cover enough of the
     // neighbors that we know the bounds are correct in each dimension. The
     // three variations here cover all of the cases.
@@ -438,6 +579,53 @@ void periodicTest()
                0 );
     EXPECT_EQ( ghosted_shared_node_space.max(Dim::K),
                halo_width );
+
+    // Check the ghosted shared node spaces again - this time with a specified
+    // halo width.
+    ghosted_shared_node_space =
+        grid_block->sharedIndexSpace( Ghost(), Node(), -1, 0, 1, 1 );
+    EXPECT_EQ( ghosted_shared_node_space.min(Dim::I),
+               owned_node_space.min(Dim::I) - 1  );
+    EXPECT_EQ( ghosted_shared_node_space.max(Dim::I),
+               owned_node_space.min(Dim::I) );
+    EXPECT_EQ( ghosted_shared_node_space.min(Dim::J),
+               owned_node_space.min(Dim::J) );
+    EXPECT_EQ( ghosted_shared_node_space.max(Dim::J),
+               owned_node_space.max(Dim::J) );
+    EXPECT_EQ( ghosted_shared_node_space.min(Dim::K),
+               owned_node_space.max(Dim::K) );
+    EXPECT_EQ( ghosted_shared_node_space.max(Dim::K),
+               owned_node_space.max(Dim::K) + 2 );
+
+    ghosted_shared_node_space =
+        grid_block->sharedIndexSpace( Ghost(), Node(), 1, -1, 0, 1 );
+    EXPECT_EQ( ghosted_shared_node_space.min(Dim::I),
+               owned_node_space.max(Dim::I) );
+    EXPECT_EQ( ghosted_shared_node_space.max(Dim::I),
+               owned_node_space.max(Dim::I) + 2 );
+    EXPECT_EQ( ghosted_shared_node_space.min(Dim::J),
+               owned_node_space.min(Dim::J) - 1 );
+    EXPECT_EQ( ghosted_shared_node_space.max(Dim::J),
+               owned_node_space.min(Dim::J) );
+    EXPECT_EQ( ghosted_shared_node_space.min(Dim::K),
+               owned_node_space.min(Dim::K) );
+    EXPECT_EQ( ghosted_shared_node_space.max(Dim::K),
+               owned_node_space.max(Dim::K) );
+
+    ghosted_shared_node_space =
+        grid_block->sharedIndexSpace( Ghost(), Node(), 0, 1, -1, 1 );
+    EXPECT_EQ( ghosted_shared_node_space.min(Dim::I),
+               owned_node_space.min(Dim::I) );
+    EXPECT_EQ( ghosted_shared_node_space.max(Dim::I),
+               owned_node_space.max(Dim::I) );
+    EXPECT_EQ( ghosted_shared_node_space.min(Dim::J),
+               owned_node_space.max(Dim::J) );
+    EXPECT_EQ( ghosted_shared_node_space.max(Dim::J),
+               owned_node_space.max(Dim::J) + 2 );
+    EXPECT_EQ( ghosted_shared_node_space.min(Dim::K),
+               owned_node_space.min(Dim::K) - 1 );
+    EXPECT_EQ( ghosted_shared_node_space.max(Dim::K),
+               owned_node_space.min(Dim::K) );
 
     //////////////////
     // I-FACE SPACES
@@ -554,6 +742,53 @@ void periodicTest()
     EXPECT_EQ( owned_shared_i_face_space.max(Dim::K),
                owned_i_face_space.min(Dim::K) + halo_width );
 
+    // Check the I-face owned shared spaces again, this time with a specified
+    // halo width.
+    owned_shared_i_face_space =
+        grid_block->sharedIndexSpace( Own(), Face<Dim::I>(), -1, 0, 1, 1 );
+    EXPECT_EQ( owned_shared_i_face_space.min(Dim::I),
+               owned_i_face_space.min(Dim::I) );
+    EXPECT_EQ( owned_shared_i_face_space.max(Dim::I),
+               owned_i_face_space.min(Dim::I) + 2);
+    EXPECT_EQ( owned_shared_i_face_space.min(Dim::J),
+               owned_i_face_space.min(Dim::J) );
+    EXPECT_EQ( owned_shared_i_face_space.max(Dim::J),
+               owned_i_face_space.max(Dim::J) );
+    EXPECT_EQ( owned_shared_i_face_space.min(Dim::K),
+               owned_i_face_space.max(Dim::K) - 1 );
+    EXPECT_EQ( owned_shared_i_face_space.max(Dim::K),
+               owned_i_face_space.max(Dim::K) );
+
+    owned_shared_i_face_space =
+        grid_block->sharedIndexSpace( Own(), Face<Dim::I>(), 1, -1, 0, 1 );
+    EXPECT_EQ( owned_shared_i_face_space.min(Dim::I),
+               owned_i_face_space.max(Dim::I) - 1 );
+    EXPECT_EQ( owned_shared_i_face_space.max(Dim::I),
+               owned_i_face_space.max(Dim::I) );
+    EXPECT_EQ( owned_shared_i_face_space.min(Dim::J),
+               owned_i_face_space.min(Dim::J) );
+    EXPECT_EQ( owned_shared_i_face_space.max(Dim::J),
+               owned_i_face_space.min(Dim::J) + 1 );
+    EXPECT_EQ( owned_shared_i_face_space.min(Dim::K),
+               owned_i_face_space.min(Dim::K) );
+    EXPECT_EQ( owned_shared_i_face_space.max(Dim::K),
+               owned_i_face_space.max(Dim::K) );
+
+    owned_shared_i_face_space =
+        grid_block->sharedIndexSpace( Own(), Face<Dim::I>(), 0, 1, -1, 1 );
+    EXPECT_EQ( owned_shared_i_face_space.min(Dim::I),
+               owned_i_face_space.min(Dim::I) );
+    EXPECT_EQ( owned_shared_i_face_space.max(Dim::I),
+               owned_i_face_space.max(Dim::I) );
+    EXPECT_EQ( owned_shared_i_face_space.min(Dim::J),
+               owned_i_face_space.max(Dim::J) - 1 );
+    EXPECT_EQ( owned_shared_i_face_space.max(Dim::J),
+               owned_i_face_space.max(Dim::J) );
+    EXPECT_EQ( owned_shared_i_face_space.min(Dim::K),
+               owned_i_face_space.min(Dim::K) );
+    EXPECT_EQ( owned_shared_i_face_space.max(Dim::K),
+               owned_i_face_space.min(Dim::K) + 1 );
+
     // Check the I-faces are ghosts that our neighbors own. Cover enough of
     // the neighbors that we know the bounds are correct in each
     // dimension. The three variations here cover all of the cases.
@@ -601,6 +836,53 @@ void periodicTest()
                0 );
     EXPECT_EQ( ghosted_shared_i_face_space.max(Dim::K),
                halo_width );
+
+    // Check the I-face ghosted shared spaces again, this time with a
+    // specified halo width.
+    ghosted_shared_i_face_space =
+        grid_block->sharedIndexSpace( Ghost(), Face<Dim::I>(), -1, 0, 1, 1 );
+    EXPECT_EQ( ghosted_shared_i_face_space.min(Dim::I),
+               owned_i_face_space.min(Dim::I) - 1 );
+    EXPECT_EQ( ghosted_shared_i_face_space.max(Dim::I),
+               owned_i_face_space.min(Dim::I) );
+    EXPECT_EQ( ghosted_shared_i_face_space.min(Dim::J),
+               owned_i_face_space.min(Dim::J) );
+    EXPECT_EQ( ghosted_shared_i_face_space.max(Dim::J),
+               owned_i_face_space.max(Dim::J) );
+    EXPECT_EQ( ghosted_shared_i_face_space.min(Dim::K),
+               owned_i_face_space.max(Dim::K) );
+    EXPECT_EQ( ghosted_shared_i_face_space.max(Dim::K),
+               owned_i_face_space.max(Dim::K) + 1 );
+
+    ghosted_shared_i_face_space =
+        grid_block->sharedIndexSpace( Ghost(), Face<Dim::I>(), 1, -1, 0, 1 );
+    EXPECT_EQ( ghosted_shared_i_face_space.min(Dim::I),
+               owned_i_face_space.max(Dim::I) );
+    EXPECT_EQ( ghosted_shared_i_face_space.max(Dim::I),
+               owned_i_face_space.max(Dim::I) + 2 );
+    EXPECT_EQ( ghosted_shared_i_face_space.min(Dim::J),
+               owned_i_face_space.min(Dim::J) - 1 );
+    EXPECT_EQ( ghosted_shared_i_face_space.max(Dim::J),
+               owned_i_face_space.min(Dim::J) );
+    EXPECT_EQ( ghosted_shared_i_face_space.min(Dim::K),
+               owned_i_face_space.min(Dim::K) );
+    EXPECT_EQ( ghosted_shared_i_face_space.max(Dim::K),
+               owned_i_face_space.max(Dim::K) );
+
+    ghosted_shared_i_face_space =
+        grid_block->sharedIndexSpace( Ghost(), Face<Dim::I>(), 0, 1, -1, 1 );
+    EXPECT_EQ( ghosted_shared_i_face_space.min(Dim::I),
+               owned_i_face_space.min(Dim::I) );
+    EXPECT_EQ( ghosted_shared_i_face_space.max(Dim::I),
+               owned_i_face_space.max(Dim::I) );
+    EXPECT_EQ( ghosted_shared_i_face_space.min(Dim::J),
+               owned_i_face_space.max(Dim::J) );
+    EXPECT_EQ( ghosted_shared_i_face_space.max(Dim::J),
+               owned_i_face_space.max(Dim::J) + 1 );
+    EXPECT_EQ( ghosted_shared_i_face_space.min(Dim::K),
+               owned_i_face_space.min(Dim::K) - 1 );
+    EXPECT_EQ( ghosted_shared_i_face_space.max(Dim::K),
+               owned_i_face_space.min(Dim::K) );
 
     //////////////////
     // J-FACE SPACES


### PR DESCRIPTION
This adds support for variable-sized halos in halo communication to enable different communication patterns over the same grid data structures. This is useful in PIC, for example, when one wants to use a large halo for particle deposition to reduce the frequency of particle communication and then use a smaller halo for grid communication during a field solve so that only the minimum grid information is transferred to complete a stencil operation.

To enable this an optional parameter is set in the `Halo` and in calls to `sharedIndexSpace` which specify the width of the halo to use for grabbing index spaces and for communication. If no value is specified, a default value equal to the halo width of the block is used.

The requested halo width must be the same size or smaller than the halo width of the block.

Closes #7