### PR TITLE
Improve Structured Solvers Interface

### DIFF
--- a/src/Cajita_StructuredSolver.hpp
+++ b/src/Cajita_StructuredSolver.hpp
@@ -20,7 +20,6 @@
 
 #include <HYPRE_struct_ls.h>
 #include <HYPRE_struct_mv.h>
-#include <HYPRE_struct_ls.h>
 
 #include <Kokkos_Core.hpp>
 
@@ -43,94 +42,110 @@ class StructuredSolver
     using entity_type = EntityType;
     using device_type = DeviceType;
     using scalar_type = Scalar;
-    template<class ... Params>
-    using array_type = Array<scalar_type,entity_type,Params...>;
+    template <class... Params>
+    using array_type = Array<scalar_type, entity_type, Params...>;
 
     /*!
       \brief Constructor.
       \param layout The array layout defining the vector space of the solver.
+      \param is_preconditioner Flag indicating if this solver will be used as
+      a preconditioner.
     */
-    StructuredSolver( const ArrayLayout<EntityType> &layout )
+    StructuredSolver( const ArrayLayout<EntityType> &layout,
+                      const bool is_preconditioner = false )
         : _comm( layout.block()->globalGrid().comm() )
+        , _is_preconditioner( is_preconditioner )
     {
-        // Create the grid.
-        auto error = HYPRE_StructGridCreate( _comm, 3, &_grid );
-        checkHypreError( error );
+        // Only create data structures if this is not a preconditioner.
+        if ( !_is_preconditioner )
+        {
+            // Create the grid.
+            auto error = HYPRE_StructGridCreate( _comm, 3, &_grid );
+            checkHypreError( error );
 
-        // Get the global index space spanned by the block on this rank. Note
-        // that the upper bound is not a bound but rather the last index as
-        // this is what Hypre wants. Note that we reordered this to KJI from
-        // IJK to be consistent with HYPRE ordering. By setting up the grid
-        // like this, HYPRE will then want layout-right data indexed as
-        // (i,j,k) or (i,j,k,l) which will allow us to directly use
-        // Kokkos::deep_copy to move data between Cajita arrays and HYPRE data
-        // structures.
-        auto global_space = layout.indexSpace( Own(), Global() );
-        _lower = {static_cast<HYPRE_Int>( global_space.min( Dim::K ) ),
-                  static_cast<HYPRE_Int>( global_space.min( Dim::J ) ),
-                  static_cast<HYPRE_Int>( global_space.min( Dim::I ) )};
-        _upper = {static_cast<HYPRE_Int>( global_space.max( Dim::K ) ) - 1,
-                  static_cast<HYPRE_Int>( global_space.max( Dim::J ) ) - 1,
-                  static_cast<HYPRE_Int>( global_space.max( Dim::I ) ) - 1};
-        error =
-            HYPRE_StructGridSetExtents( _grid, _lower.data(), _upper.data() );
-        checkHypreError( error );
+            // Get the global index space spanned by the block on this rank.
+            // Note that the upper bound is not a bound but rather the last
+            // index as this is what Hypre wants. Note that we reordered this to
+            // KJI from IJK to be consistent with HYPRE ordering. By setting up
+            // the grid like this, HYPRE will then want layout-right data
+            // indexed as (i,j,k) or (i,j,k,l) which will allow us to directly
+            // use Kokkos::deep_copy to move data between Cajita arrays and
+            // HYPRE data structures.
+            auto global_space = layout.indexSpace( Own(), Global() );
+            _lower = {static_cast<HYPRE_Int>( global_space.min( Dim::K ) ),
+                      static_cast<HYPRE_Int>( global_space.min( Dim::J ) ),
+                      static_cast<HYPRE_Int>( global_space.min( Dim::I ) )};
+            _upper = {static_cast<HYPRE_Int>( global_space.max( Dim::K ) ) - 1,
+                      static_cast<HYPRE_Int>( global_space.max( Dim::J ) ) - 1,
+                      static_cast<HYPRE_Int>( global_space.max( Dim::I ) ) - 1};
+            error = HYPRE_StructGridSetExtents( _grid, _lower.data(),
+                                                _upper.data() );
+            checkHypreError( error );
 
-        // Get periodicity. Note we invert the order of this to KJI as well.
-        const auto &domain = layout.block()->globalGrid().domain();
-        HYPRE_Int periodic[3];
-        for ( int d = 0; d < 3; ++d )
-            periodic[2 - d] = domain.isPeriodic( d )
-                              ? layout.block()->globalGrid().globalNumEntity(
-                                  EntityType(), d )
-                              : 0;
-        error = HYPRE_StructGridSetPeriodic( _grid, periodic );
-        checkHypreError( error );
+            // Get periodicity. Note we invert the order of this to KJI as well.
+            const auto &domain = layout.block()->globalGrid().domain();
+            HYPRE_Int periodic[3];
+            for ( int d = 0; d < 3; ++d )
+                periodic[2 - d] =
+                    domain.isPeriodic( d )
+                        ? layout.block()->globalGrid().globalNumEntity(
+                              EntityType(), d )
+                        : 0;
+            error = HYPRE_StructGridSetPeriodic( _grid, periodic );
+            checkHypreError( error );
 
-        // Assemble the grid.
-        error = HYPRE_StructGridAssemble( _grid );
-        checkHypreError( error );
+            // Assemble the grid.
+            error = HYPRE_StructGridAssemble( _grid );
+            checkHypreError( error );
 
-        // Allocate LHS and RHS vectors and initialize to zero. Note that we
-        // are fixing the views under these vectors to layout-right.
-        IndexSpace<3> reorder_space( {global_space.extent( Dim::I ),
-                                      global_space.extent( Dim::J ),
-                                      global_space.extent( Dim::K )} );
-        auto vector_values =
-            createView<double, Kokkos::LayoutRight, Kokkos::HostSpace>(
-                "vector_values", reorder_space );
-        Kokkos::deep_copy( vector_values, 0.0 );
+            // Allocate LHS and RHS vectors and initialize to zero. Note that we
+            // are fixing the views under these vectors to layout-right.
+            IndexSpace<3> reorder_space( {global_space.extent( Dim::I ),
+                                          global_space.extent( Dim::J ),
+                                          global_space.extent( Dim::K )} );
+            auto vector_values =
+                createView<double, Kokkos::LayoutRight, Kokkos::HostSpace>(
+                    "vector_values", reorder_space );
+            Kokkos::deep_copy( vector_values, 0.0 );
 
-        error = HYPRE_StructVectorCreate( _comm, _grid, &_b );
-        checkHypreError( error );
-        error = HYPRE_StructVectorInitialize( _b );
-        checkHypreError( error );
-        error = HYPRE_StructVectorSetBoxValues(
-            _b, _lower.data(), _upper.data(), vector_values.data() );
-        checkHypreError( error );
-        error = HYPRE_StructVectorAssemble( _b );
-        checkHypreError( error );
+            error = HYPRE_StructVectorCreate( _comm, _grid, &_b );
+            checkHypreError( error );
+            error = HYPRE_StructVectorInitialize( _b );
+            checkHypreError( error );
+            error = HYPRE_StructVectorSetBoxValues(
+                _b, _lower.data(), _upper.data(), vector_values.data() );
+            checkHypreError( error );
+            error = HYPRE_StructVectorAssemble( _b );
+            checkHypreError( error );
 
-        error = HYPRE_StructVectorCreate( _comm, _grid, &_x );
-        checkHypreError( error );
-        error = HYPRE_StructVectorInitialize( _x );
-        checkHypreError( error );
-        error = HYPRE_StructVectorSetBoxValues(
-            _x, _lower.data(), _upper.data(), vector_values.data() );
-        checkHypreError( error );
-        error = HYPRE_StructVectorAssemble( _x );
-        checkHypreError( error );
+            error = HYPRE_StructVectorCreate( _comm, _grid, &_x );
+            checkHypreError( error );
+            error = HYPRE_StructVectorInitialize( _x );
+            checkHypreError( error );
+            error = HYPRE_StructVectorSetBoxValues(
+                _x, _lower.data(), _upper.data(), vector_values.data() );
+            checkHypreError( error );
+            error = HYPRE_StructVectorAssemble( _x );
+            checkHypreError( error );
+        }
     }
 
     // Destructor.
     virtual ~StructuredSolver()
     {
-        HYPRE_StructVectorDestroy( _x );
-        HYPRE_StructVectorDestroy( _b );
-        HYPRE_StructMatrixDestroy( _A );
-        HYPRE_StructStencilDestroy( _stencil );
-        HYPRE_StructGridDestroy( _grid );
+        // We only make data if this is not a preconditioner.
+        if ( !_is_preconditioner )
+        {
+            HYPRE_StructVectorDestroy( _x );
+            HYPRE_StructVectorDestroy( _b );
+            HYPRE_StructMatrixDestroy( _A );
+            HYPRE_StructStencilDestroy( _stencil );
+            HYPRE_StructGridDestroy( _grid );
+        }
     }
+
+    //! Return if this solver is a preconditioner.
+    bool isPreconditioner() const { return _is_preconditioner; }
 
     /*!
       \brief Set the operator stencil.
@@ -143,6 +158,11 @@ class StructuredSolver
     void setMatrixStencil( const std::vector<std::array<int, 3>> &stencil,
                            const bool is_symmetric = false )
     {
+        // This function is only valid for non-preconditioners.
+        if ( _is_preconditioner )
+            throw std::logic_error(
+                "Cannot call setMatrixStencil() on preconditioners" );
+
         // Create the stencil.
         _stencil_size = stencil.size();
         auto error = HYPRE_StructStencilCreate( 3, _stencil_size, &_stencil );
@@ -170,12 +190,17 @@ class StructuredSolver
       stencil definition. Note that values corresponding to stencil entries
       outside of the domain should be set to zero.
     */
-    template <class ... ArrayParams>
+    template <class... ArrayParams>
     void setMatrixValues( const array_type<ArrayParams...> &values )
     {
+        // This function is only valid for non-preconditioners.
+        if ( _is_preconditioner )
+            throw std::logic_error(
+                "Cannot call setMatrixValues() on preconditioners" );
+
         static_assert(
             std::is_same<typename array_type<ArrayParams...>::device_type,
-            DeviceType>::value,
+                         DeviceType>::value,
             "Array device type and solver device type are different." );
 
         if ( values.layout()->dofsPerEntity() !=
@@ -226,21 +251,50 @@ class StructuredSolver
         this->setPrintLevelImpl( print_level );
     }
 
+    // Set a preconditioner.
+    void setPreconditioner(
+        const std::shared_ptr<StructuredSolver<Scalar, EntityType, DeviceType>>
+            &preconditioner )
+    {
+        // This function is only valid for non-preconditioners.
+        if ( _is_preconditioner )
+            throw std::logic_error(
+                "Cannot call setPreconditioner() on a preconditioner" );
+
+        // Only a preconditioner can be used as a preconditioner.
+        if ( !preconditioner->isPreconditioner() )
+            throw std::logic_error( "Not a preconditioner" );
+
+        _preconditioner = preconditioner;
+        this->setPreconditionerImpl( *_preconditioner );
+    }
+
     // Setup the problem.
-    void setup() { this->setupImpl( _A, _b, _x ); }
+    void setup()
+    {
+        // This function is only valid for non-preconditioners.
+        if ( _is_preconditioner )
+            throw std::logic_error( "Cannot call setup() on preconditioners" );
+
+        this->setupImpl( _A, _b, _x );
+    }
 
     /*!
       \brief Solve the problem Ax = b for x.
       \param b The forcing term.
       \param x The solution.
     */
-    template <class ... ArrayParams>
+    template <class... ArrayParams>
     void solve( const array_type<ArrayParams...> &b,
                 array_type<ArrayParams...> &x )
     {
+        // This function is only valid for non-preconditioners.
+        if ( _is_preconditioner )
+            throw std::logic_error( "Cannot call solve() on preconditioners" );
+
         static_assert(
             std::is_same<typename array_type<ArrayParams...>::device_type,
-            DeviceType>::value,
+                         DeviceType>::value,
             "Array device type and solver device type are different." );
 
         if ( b.layout()->dofsPerEntity() != 1 ||
@@ -255,14 +309,13 @@ class StructuredSolver
         // Get a local view of b on the host.
         auto owned_space = b.layout()->indexSpace( Own(), Local() );
         auto owned_b = createSubview( b.view(), owned_space );
-        auto b_mirror = Kokkos::create_mirror_view_and_copy(
-            Kokkos::HostSpace(), owned_b );
+        auto b_mirror =
+            Kokkos::create_mirror_view_and_copy( Kokkos::HostSpace(), owned_b );
 
         // Copy the RHS into HYPRE. The HYPRE layout is fixed as layout-right.
         IndexSpace<4> reorder_space( {owned_space.extent( Dim::I ),
                                       owned_space.extent( Dim::J ),
-                                      owned_space.extent( Dim::K ),
-                                      1} );
+                                      owned_space.extent( Dim::K ), 1} );
         auto vector_values =
             createView<double, Kokkos::LayoutRight, Kokkos::HostSpace>(
                 "vector_values", reorder_space );
@@ -285,8 +338,8 @@ class StructuredSolver
 
         // Get a local view of x on the host.
         auto owned_x = createSubview( x.view(), owned_space );
-        auto x_mirror = Kokkos::create_mirror_view(
-            Kokkos::HostSpace(), owned_x );
+        auto x_mirror =
+            Kokkos::create_mirror_view( Kokkos::HostSpace(), owned_x );
 
         // Copy the HYPRE solution to the LHS.
         Kokkos::deep_copy( x_mirror, vector_values );
@@ -301,6 +354,11 @@ class StructuredSolver
     {
         return this->getFinalRelativeResidualNormImpl();
     }
+
+    //! Preconditioner implementation details.
+    virtual HYPRE_StructSolver getHypreSolver() const = 0;
+    virtual HYPRE_PtrToStructSolverFcn getHypreSetupFunction() const = 0;
+    virtual HYPRE_PtrToStructSolverFcn getHypreSolveFunction() const = 0;
 
   protected:
     // Set convergence tolerance implementation.
@@ -326,6 +384,11 @@ class StructuredSolver
     // Get the relative residual norm achieved on the last solve.
     virtual double getFinalRelativeResidualNormImpl() = 0;
 
+    // Set a preconditioner.
+    virtual void setPreconditionerImpl(
+        const StructuredSolver<Scalar, EntityType, DeviceType>
+            &preconditioner ) = 0;
+
     // Check a hypre error.
     void checkHypreError( const int error ) const
     {
@@ -340,6 +403,7 @@ class StructuredSolver
 
   private:
     MPI_Comm _comm;
+    bool _is_preconditioner;
     HYPRE_StructGrid _grid;
     std::array<HYPRE_Int, 3> _lower;
     std::array<HYPRE_Int, 3> _upper;
@@ -348,6 +412,8 @@ class StructuredSolver
     HYPRE_StructMatrix _A;
     HYPRE_StructVector _b;
     HYPRE_StructVector _x;
+    std::shared_ptr<StructuredSolver<Scalar, EntityType, DeviceType>>
+        _preconditioner;
 };
 
 //---------------------------------------------------------------------------//
@@ -358,15 +424,56 @@ class HypreStructPCG : public StructuredSolver<Scalar, EntityType, DeviceType>
   public:
     using Base = StructuredSolver<Scalar, EntityType, DeviceType>;
 
-    HypreStructPCG( const ArrayLayout<EntityType> &layout )
-        : Base( layout )
+    HypreStructPCG( const ArrayLayout<EntityType> &layout,
+                    const bool is_preconditioner = false )
+        : Base( layout, is_preconditioner )
     {
+        if ( is_preconditioner )
+            throw std::logic_error(
+                "HYPRE PCG cannot be used as a preconditioner" );
+
         auto error = HYPRE_StructPCGCreate( layout.block()->globalGrid().comm(),
                                             &_solver );
         this->checkHypreError( error );
+
+        HYPRE_StructPCGSetTwoNorm( _solver, 1 );
     }
 
     ~HypreStructPCG() { HYPRE_StructPCGDestroy( _solver ); }
+
+    //! PCG SETTINGS
+
+    // Set the absolute tolerance
+    void setAbsoluteTol( const double tol )
+    {
+        auto error = HYPRE_StructPCGSetAbsoluteTol( _solver, tol );
+        this->checkHypreError( error );
+    }
+
+    // Additionally require that the relative difference in successive
+    // iterates be small.
+    void setRelChange( const int rel_change )
+    {
+        auto error = HYPRE_StructPCGSetRelChange( _solver, rel_change );
+        this->checkHypreError( error );
+    }
+
+    // Set the amount of logging to do.
+    void setLogging( const int logging )
+    {
+        auto error = HYPRE_StructPCGSetLogging( _solver, logging );
+        this->checkHypreError( error );
+    }
+
+    HYPRE_StructSolver getHypreSolver() const override { return _solver; }
+    HYPRE_PtrToStructSolverFcn getHypreSetupFunction() const override
+    {
+        return HYPRE_StructPCGSetup;
+    }
+    HYPRE_PtrToStructSolverFcn getHypreSolveFunction() const override
+    {
+        return HYPRE_StructPCGSolve;
+    }
 
   protected:
     void setToleranceImpl( const double tol ) override
@@ -418,6 +525,17 @@ class HypreStructPCG : public StructuredSolver<Scalar, EntityType, DeviceType>
         return norm;
     }
 
+    void setPreconditionerImpl(
+        const StructuredSolver<Scalar, EntityType, DeviceType> &preconditioner )
+        override
+    {
+        auto error = HYPRE_StructPCGSetPrecond(
+            _solver, preconditioner.getHypreSolveFunction(),
+            preconditioner.getHypreSetupFunction(),
+            preconditioner.getHypreSolver() );
+        this->checkHypreError( error );
+    }
+
   private:
     HYPRE_StructSolver _solver;
 };
@@ -430,15 +548,53 @@ class HypreStructGMRES : public StructuredSolver<Scalar, EntityType, DeviceType>
   public:
     using Base = StructuredSolver<Scalar, EntityType, DeviceType>;
 
-    HypreStructGMRES( const ArrayLayout<EntityType> &layout )
-        : Base( layout )
+    HypreStructGMRES( const ArrayLayout<EntityType> &layout,
+                      const bool is_preconditioner = false )
+        : Base( layout, is_preconditioner )
     {
+        if ( is_preconditioner )
+            throw std::logic_error(
+                "HYPRE GMRES cannot be used as a preconditioner" );
+
         auto error = HYPRE_StructGMRESCreate(
             layout.block()->globalGrid().comm(), &_solver );
         this->checkHypreError( error );
     }
 
     ~HypreStructGMRES() { HYPRE_StructGMRESDestroy( _solver ); }
+
+    //! GMRES SETTINGS
+
+    // Set the absolute tolerance
+    void setAbsoluteTol( const double tol )
+    {
+        auto error = HYPRE_StructGMRESSetAbsoluteTol( _solver, tol );
+        this->checkHypreError( error );
+    }
+
+    // Set the max size of the Krylov space.
+    void setKDim( const int k_dim )
+    {
+        auto error = HYPRE_StructGMRESSetKDim( _solver, k_dim );
+        this->checkHypreError( error );
+    }
+
+    // Set the amount of logging to do.
+    void setLogging( const int logging )
+    {
+        auto error = HYPRE_StructGMRESSetLogging( _solver, logging );
+        this->checkHypreError( error );
+    }
+
+    HYPRE_StructSolver getHypreSolver() const override { return _solver; }
+    HYPRE_PtrToStructSolverFcn getHypreSetupFunction() const override
+    {
+        return HYPRE_StructGMRESSetup;
+    }
+    HYPRE_PtrToStructSolverFcn getHypreSolveFunction() const override
+    {
+        return HYPRE_StructGMRESSolve;
+    }
 
   protected:
     void setToleranceImpl( const double tol ) override
@@ -490,6 +646,132 @@ class HypreStructGMRES : public StructuredSolver<Scalar, EntityType, DeviceType>
         return norm;
     }
 
+    void setPreconditionerImpl(
+        const StructuredSolver<Scalar, EntityType, DeviceType> &preconditioner )
+        override
+    {
+        auto error = HYPRE_StructGMRESSetPrecond(
+            _solver, preconditioner.getHypreSolveFunction(),
+            preconditioner.getHypreSetupFunction(),
+            preconditioner.getHypreSolver() );
+        this->checkHypreError( error );
+    }
+
+  private:
+    HYPRE_StructSolver _solver;
+};
+
+//---------------------------------------------------------------------------//
+// BiCGSTAB solver.
+template <class Scalar, class EntityType, class DeviceType>
+class HypreStructBiCGSTAB
+    : public StructuredSolver<Scalar, EntityType, DeviceType>
+{
+  public:
+    using Base = StructuredSolver<Scalar, EntityType, DeviceType>;
+
+    HypreStructBiCGSTAB( const ArrayLayout<EntityType> &layout,
+                         const bool is_preconditioner = false )
+        : Base( layout, is_preconditioner )
+    {
+        if ( is_preconditioner )
+            throw std::logic_error(
+                "HYPRE BiCGSTAB cannot be used as a preconditioner" );
+
+        auto error = HYPRE_StructBiCGSTABCreate(
+            layout.block()->globalGrid().comm(), &_solver );
+        this->checkHypreError( error );
+    }
+
+    ~HypreStructBiCGSTAB() { HYPRE_StructBiCGSTABDestroy( _solver ); }
+
+    //! BiCGSTAB SETTINGS
+
+    // Set the absolute tolerance
+    void setAbsoluteTol( const double tol )
+    {
+        auto error = HYPRE_StructBiCGSTABSetAbsoluteTol( _solver, tol );
+        this->checkHypreError( error );
+    }
+
+    // Set the amount of logging to do.
+    void setLogging( const int logging )
+    {
+        auto error = HYPRE_StructBiCGSTABSetLogging( _solver, logging );
+        this->checkHypreError( error );
+    }
+
+    HYPRE_StructSolver getHypreSolver() const override { return _solver; }
+    HYPRE_PtrToStructSolverFcn getHypreSetupFunction() const override
+    {
+        return HYPRE_StructBiCGSTABSetup;
+    }
+    HYPRE_PtrToStructSolverFcn getHypreSolveFunction() const override
+    {
+        return HYPRE_StructBiCGSTABSolve;
+    }
+
+  protected:
+    void setToleranceImpl( const double tol ) override
+    {
+        auto error = HYPRE_StructBiCGSTABSetTol( _solver, tol );
+        this->checkHypreError( error );
+    }
+
+    void setMaxIterImpl( const int max_iter ) override
+    {
+        auto error = HYPRE_StructBiCGSTABSetMaxIter( _solver, max_iter );
+        this->checkHypreError( error );
+    }
+
+    void setPrintLevelImpl( const int print_level ) override
+    {
+        auto error = HYPRE_StructBiCGSTABSetPrintLevel( _solver, print_level );
+        this->checkHypreError( error );
+    }
+
+    void setupImpl( HYPRE_StructMatrix A, HYPRE_StructVector b,
+                    HYPRE_StructVector x ) override
+    {
+        auto error = HYPRE_StructBiCGSTABSetup( _solver, A, b, x );
+        this->checkHypreError( error );
+    }
+
+    void solveImpl( HYPRE_StructMatrix A, HYPRE_StructVector b,
+                    HYPRE_StructVector x ) override
+    {
+        auto error = HYPRE_StructBiCGSTABSolve( _solver, A, b, x );
+        this->checkHypreError( error );
+    }
+
+    int getNumIterImpl() override
+    {
+        HYPRE_Int num_iter;
+        auto error = HYPRE_StructBiCGSTABGetNumIterations( _solver, &num_iter );
+        this->checkHypreError( error );
+        return num_iter;
+    }
+
+    double getFinalRelativeResidualNormImpl() override
+    {
+        HYPRE_Real norm;
+        auto error =
+            HYPRE_StructBiCGSTABGetFinalRelativeResidualNorm( _solver, &norm );
+        this->checkHypreError( error );
+        return norm;
+    }
+
+    void setPreconditionerImpl(
+        const StructuredSolver<Scalar, EntityType, DeviceType> &preconditioner )
+        override
+    {
+        auto error = HYPRE_StructBiCGSTABSetPrecond(
+            _solver, preconditioner.getHypreSolveFunction(),
+            preconditioner.getHypreSetupFunction(),
+            preconditioner.getHypreSolver() );
+        this->checkHypreError( error );
+    }
+
   private:
     HYPRE_StructSolver _solver;
 };
@@ -502,15 +784,112 @@ class HypreStructPFMG : public StructuredSolver<Scalar, EntityType, DeviceType>
   public:
     using Base = StructuredSolver<Scalar, EntityType, DeviceType>;
 
-    HypreStructPFMG( const ArrayLayout<EntityType> &layout )
-        : Base( layout )
+    HypreStructPFMG( const ArrayLayout<EntityType> &layout,
+                     const bool is_preconditioner = false )
+        : Base( layout, is_preconditioner )
     {
         auto error = HYPRE_StructPFMGCreate(
             layout.block()->globalGrid().comm(), &_solver );
         this->checkHypreError( error );
+
+        if ( is_preconditioner )
+        {
+            error = HYPRE_StructPFMGSetZeroGuess( _solver );
+            this->checkHypreError( error );
+        }
     }
 
     ~HypreStructPFMG() { HYPRE_StructPFMGDestroy( _solver ); }
+
+    //! PFMG SETTINGS
+
+    // Set the maximum number of multigrid levels.
+    void setMaxLevels( const int max_levels )
+    {
+        auto error = HYPRE_StructPFMGSetMaxLevels( _solver, max_levels );
+        this->checkHypreError( error );
+    }
+
+    // Additionally require that the relative difference in successive
+    // iterates be small.
+    void setRelChange( const int rel_change )
+    {
+        auto error = HYPRE_StructPFMGSetRelChange( _solver, rel_change );
+        this->checkHypreError( error );
+    }
+
+    // Set relaxation type.
+    // 0 - Jacobi
+    // 1 - Weighted Jacobi (default)
+    // 2 - Red/Black Gauss-Seidel (symmetric: RB pre-relaxation, BR
+    // post-relaxation) 3 - Red/Black Gauss-Seidel (nonsymmetric: RB pre- and
+    // post-relaxation)
+    void setRelaxType( const int relax_type )
+    {
+        auto error = HYPRE_StructPFMGSetRelaxType( _solver, relax_type );
+        this->checkHypreError( error );
+    }
+
+    // Set the Jacobi weight
+    void setJacobiWeight( const double weight )
+    {
+        auto error = HYPRE_StructPFMGSetJacobiWeight( _solver, weight );
+        this->checkHypreError( error );
+    }
+
+    // Set type of coarse-grid operator to use.
+    //
+    // 0 - Galerkin (default)
+    // 1 - non-Galerkin 5-pt or 7-pt stencils
+    //
+    // Both operators are constructed algebraically.  The non-Galerkin option
+    // maintains a 5-pt stencil in 2D and a 7-pt stencil in 3D on all grid
+    // levels. The stencil coefficients are computed by averaging techniques.
+    void setRAPType( const int rap_type )
+    {
+        auto error = HYPRE_StructPFMGSetRAPType( _solver, rap_type );
+        this->checkHypreError( error );
+    }
+
+    // Set number of relaxation sweeps before coarse-grid correction.
+    void setNumPreRelax( const int num_pre_relax )
+    {
+        auto error = HYPRE_StructPFMGSetNumPreRelax( _solver, num_pre_relax );
+        this->checkHypreError( error );
+    }
+
+    // Set number of relaxation sweeps before coarse-grid correction.
+    void setNumPostRelax( const int num_post_relax )
+    {
+        auto error = HYPRE_StructPFMGSetNumPostRelax( _solver, num_post_relax );
+        this->checkHypreError( error );
+    }
+
+    // Skip relaxation on certain grids for isotropic problems.  This can
+    // greatly improve efficiency by eliminating unnecessary relaxations when
+    // the underlying problem is isotropic.
+    void setSkipRelax( const int skip_relax )
+    {
+        auto error = HYPRE_StructPFMGSetSkipRelax( _solver, skip_relax );
+        this->checkHypreError( error );
+    }
+
+    // Set the amount of logging to do.
+    void setLogging( const int logging )
+    {
+        auto error = HYPRE_StructPFMGSetLogging( _solver, logging );
+        this->checkHypreError( error );
+    }
+
+    HYPRE_StructSolver getHypreSolver() const override { return _solver; }
+    HYPRE_PtrToStructSolverFcn getHypreSetupFunction() const override
+    {
+        return HYPRE_StructPFMGSetup;
+    }
+    HYPRE_PtrToStructSolverFcn getHypreSolveFunction() const override
+    {
+        return HYPRE_StructPFMGSolve;
+    }
 
   protected:
     void setToleranceImpl( const double tol ) override
@@ -562,6 +941,13 @@ class HypreStructPFMG : public StructuredSolver<Scalar, EntityType, DeviceType>
         return norm;
     }
 
+    void setPreconditionerImpl(
+        const StructuredSolver<Scalar, EntityType, DeviceType> & ) override
+    {
+        throw std::logic_error(
+            "HYPRE PFMG solver does not support preconditioning." );
+    }
+
   private:
     HYPRE_StructSolver _solver;
 };
@@ -574,15 +960,63 @@ class HypreStructSMG : public StructuredSolver<Scalar, EntityType, DeviceType>
   public:
     using Base = StructuredSolver<Scalar, EntityType, DeviceType>;
 
-    HypreStructSMG( const ArrayLayout<EntityType> &layout )
-        : Base( layout )
+    HypreStructSMG( const ArrayLayout<EntityType> &layout,
+                    const bool is_preconditioner = false )
+        : Base( layout, is_preconditioner )
     {
         auto error = HYPRE_StructSMGCreate( layout.block()->globalGrid().comm(),
                                             &_solver );
         this->checkHypreError( error );
+
+        if ( is_preconditioner )
+        {
+            error = HYPRE_StructSMGSetZeroGuess( _solver );
+            this->checkHypreError( error );
+        }
     }
 
     ~HypreStructSMG() { HYPRE_StructSMGDestroy( _solver ); }
+
+    //! SMG Settings
+
+    // Additionally require that the relative difference in successive
+    // iterates be small.
+    void setRelChange( const int rel_change )
+    {
+        auto error = HYPRE_StructSMGSetRelChange( _solver, rel_change );
+        this->checkHypreError( error );
+    }
+
+    // Set number of relaxation sweeps before coarse-grid correction.
+    void setNumPreRelax( const int num_pre_relax )
+    {
+        auto error = HYPRE_StructSMGSetNumPreRelax( _solver, num_pre_relax );
+        this->checkHypreError( error );
+    }
+
+    // Set number of relaxation sweeps before coarse-grid correction.
+    void setNumPostRelax( const int num_post_relax )
+    {
+        auto error = HYPRE_StructSMGSetNumPostRelax( _solver, num_post_relax );
+        this->checkHypreError( error );
+    }
+
+    // Set the amount of logging to do.
+    void setLogging( const int logging )
+    {
+        auto error = HYPRE_StructSMGSetLogging( _solver, logging );
+        this->checkHypreError( error );
+    }
+
+    HYPRE_StructSolver getHypreSolver() const override { return _solver; }
+    HYPRE_PtrToStructSolverFcn getHypreSetupFunction() const override
+    {
+        return HYPRE_StructSMGSetup;
+    }
+    HYPRE_PtrToStructSolverFcn getHypreSolveFunction() const override
+    {
+        return HYPRE_StructSMGSolve;
+    }
 
   protected:
     void setToleranceImpl( const double tol ) override
@@ -634,9 +1068,261 @@ class HypreStructSMG : public StructuredSolver<Scalar, EntityType, DeviceType>
         return norm;
     }
 
+    void setPreconditionerImpl(
+        const StructuredSolver<Scalar, EntityType, DeviceType> & ) override
+    {
+        throw std::logic_error(
+            "HYPRE SMG solver does not support preconditioning." );
+    }
+
   private:
     HYPRE_StructSolver _solver;
 };
+
+//---------------------------------------------------------------------------//
+// Jacobi solver.
+template <class Scalar, class EntityType, class DeviceType>
+class HypreStructJacobi
+    : public StructuredSolver<Scalar, EntityType, DeviceType>
+{
+  public:
+    using Base = StructuredSolver<Scalar, EntityType, DeviceType>;
+
+    HypreStructJacobi( const ArrayLayout<EntityType> &layout,
+                       const bool is_preconditioner = false )
+        : Base( layout, is_preconditioner )
+    {
+        auto error = HYPRE_StructJacobiCreate(
+            layout.block()->globalGrid().comm(), &_solver );
+        this->checkHypreError( error );
+
+        if ( is_preconditioner )
+        {
+            error = HYPRE_StructJacobiSetZeroGuess( _solver );
+            this->checkHypreError( error );
+        }
+    }
+
+    ~HypreStructJacobi() { HYPRE_StructJacobiDestroy( _solver ); }
+
+    HYPRE_StructSolver getHypreSolver() const override { return _solver; }
+    HYPRE_PtrToStructSolverFcn getHypreSetupFunction() const override
+    {
+        return HYPRE_StructJacobiSetup;
+    }
+    HYPRE_PtrToStructSolverFcn getHypreSolveFunction() const override
+    {
+        return HYPRE_StructJacobiSolve;
+    }
+
+  protected:
+    void setToleranceImpl( const double tol ) override
+    {
+        auto error = HYPRE_StructJacobiSetTol( _solver, tol );
+        this->checkHypreError( error );
+    }
+
+    void setMaxIterImpl( const int max_iter ) override
+    {
+        auto error = HYPRE_StructJacobiSetMaxIter( _solver, max_iter );
+        this->checkHypreError( error );
+    }
+
+    void setPrintLevelImpl( const int ) override
+    {
+        // The Jacobi solver does not support a print level.
+    }
+
+    void setupImpl( HYPRE_StructMatrix A, HYPRE_StructVector b,
+                    HYPRE_StructVector x ) override
+    {
+        auto error = HYPRE_StructJacobiSetup( _solver, A, b, x );
+        this->checkHypreError( error );
+    }
+
+    void solveImpl( HYPRE_StructMatrix A, HYPRE_StructVector b,
+                    HYPRE_StructVector x ) override
+    {
+        auto error = HYPRE_StructJacobiSolve( _solver, A, b, x );
+        this->checkHypreError( error );
+    }
+
+    int getNumIterImpl() override
+    {
+        HYPRE_Int num_iter;
+        auto error = HYPRE_StructJacobiGetNumIterations( _solver, &num_iter );
+        this->checkHypreError( error );
+        return num_iter;
+    }
+
+    double getFinalRelativeResidualNormImpl() override
+    {
+        HYPRE_Real norm;
+        auto error =
+            HYPRE_StructJacobiGetFinalRelativeResidualNorm( _solver, &norm );
+        this->checkHypreError( error );
+        return norm;
+    }
+
+    void setPreconditionerImpl(
+        const StructuredSolver<Scalar, EntityType, DeviceType> & ) override
+    {
+        throw std::logic_error(
+            "HYPRE Jacobi solver does not support preconditioning." );
+    }
+
+  private:
+    HYPRE_StructSolver _solver;
+};
+
+//---------------------------------------------------------------------------//
+// Diagonal preconditioner.
+template <class Scalar, class EntityType, class DeviceType>
+class HypreStructDiagonal
+    : public StructuredSolver<Scalar, EntityType, DeviceType>
+{
+  public:
+    using Base = StructuredSolver<Scalar, EntityType, DeviceType>;
+
+    HypreStructDiagonal( const ArrayLayout<EntityType> &layout,
+                         const bool is_preconditioner = false )
+        : Base( layout, is_preconditioner )
+    {
+        if ( !is_preconditioner )
+            throw std::logic_error(
+                "Diagonal preconditioner cannot be used as a solver" );
+    }
+
+    HYPRE_StructSolver getHypreSolver() const override { return nullptr; }
+    HYPRE_PtrToStructSolverFcn getHypreSetupFunction() const override
+    {
+        return HYPRE_StructDiagScaleSetup;
+    }
+    HYPRE_PtrToStructSolverFcn getHypreSolveFunction() const override
+    {
+        return HYPRE_StructDiagScale;
+    }
+
+  protected:
+    void setToleranceImpl( const double ) override
+    {
+        throw std::logic_error(
+            "Diagonal preconditioner cannot be used as a solver" );
+    }
+
+    void setMaxIterImpl( const int ) override
+    {
+        throw std::logic_error(
+            "Diagonal preconditioner cannot be used as a solver" );
+    }
+
+    void setPrintLevelImpl( const int ) override
+    {
+        throw std::logic_error(
+            "Diagonal preconditioner cannot be used as a solver" );
+    }
+
+    void setupImpl( HYPRE_StructMatrix, HYPRE_StructVector,
+                    HYPRE_StructVector ) override
+    {
+        throw std::logic_error(
+            "Diagonal preconditioner cannot be used as a solver" );
+    }
+
+    void solveImpl( HYPRE_StructMatrix, HYPRE_StructVector,
+                    HYPRE_StructVector ) override
+    {
+        throw std::logic_error(
+            "Diagonal preconditioner cannot be used as a solver" );
+    }
+
+    int getNumIterImpl() override
+    {
+        throw std::logic_error(
+            "Diagonal preconditioner cannot be used as a solver" );
+    }
+
+    double getFinalRelativeResidualNormImpl() override
+    {
+        throw std::logic_error(
+            "Diagonal preconditioner cannot be used as a solver" );
+    }
+
+    void setPreconditionerImpl(
+        const StructuredSolver<Scalar, EntityType, DeviceType> & ) override
+    {
+        throw std::logic_error(
+            "Diagonal preconditioner does not support preconditioning." );
+    }
+};
+
+//---------------------------------------------------------------------------//
+// Builders
+//---------------------------------------------------------------------------//
+template <class Scalar, class DeviceType, class EntityType>
+std::shared_ptr<HypreStructPCG<Scalar, EntityType, DeviceType>>
+createHypreStructPCG( const ArrayLayout<EntityType> &layout,
+                      const bool is_preconditioner = false )
+{
+    return std::make_shared<HypreStructPCG<Scalar, EntityType, DeviceType>>(
+        layout, is_preconditioner );
+}
+
+template <class Scalar, class DeviceType, class EntityType>
+std::shared_ptr<HypreStructGMRES<Scalar, EntityType, DeviceType>>
+createHypreStructGMRES( const ArrayLayout<EntityType> &layout,
+                        const bool is_preconditioner = false )
+{
+    return std::make_shared<HypreStructGMRES<Scalar, EntityType, DeviceType>>(
+        layout, is_preconditioner );
+}
+
+template <class Scalar, class DeviceType, class EntityType>
+std::shared_ptr<HypreStructBiCGSTAB<Scalar, EntityType, DeviceType>>
+createHypreStructBiCGSTAB( const ArrayLayout<EntityType> &layout,
+                           const bool is_preconditioner = false )
+{
+    return std::make_shared<
+        HypreStructBiCGSTAB<Scalar, EntityType, DeviceType>>(
+        layout, is_preconditioner );
+}
+
+template <class Scalar, class DeviceType, class EntityType>
+std::shared_ptr<HypreStructPFMG<Scalar, EntityType, DeviceType>>
+createHypreStructPFMG( const ArrayLayout<EntityType> &layout,
+                       const bool is_preconditioner = false )
+{
+    return std::make_shared<HypreStructPFMG<Scalar, EntityType, DeviceType>>(
+        layout, is_preconditioner );
+}
+
+template <class Scalar, class DeviceType, class EntityType>
+std::shared_ptr<HypreStructSMG<Scalar, EntityType, DeviceType>>
+createHypreStructSMG( const ArrayLayout<EntityType> &layout,
+                      const bool is_preconditioner = false )
+{
+    return std::make_shared<HypreStructSMG<Scalar, EntityType, DeviceType>>(
+        layout, is_preconditioner );
+}
+
+template <class Scalar, class DeviceType, class EntityType>
+std::shared_ptr<HypreStructJacobi<Scalar, EntityType, DeviceType>>
+createHypreStructJacobi( const ArrayLayout<EntityType> &layout,
+                         const bool is_preconditioner = false )
+{
+    return std::make_shared<HypreStructJacobi<Scalar, EntityType, DeviceType>>(
+        layout, is_preconditioner );
+}
+
+template <class Scalar, class DeviceType, class EntityType>
+std::shared_ptr<HypreStructDiagonal<Scalar, EntityType, DeviceType>>
+createHypreStructDiagonal( const ArrayLayout<EntityType> &layout,
+                           const bool is_preconditioner = false )
+{
+    return std::make_shared<
+        HypreStructDiagonal<Scalar, EntityType, DeviceType>>(
+        layout, is_preconditioner );
+}
 
 //---------------------------------------------------------------------------//
 // Factory
@@ -644,20 +1330,30 @@ class HypreStructSMG : public StructuredSolver<Scalar, EntityType, DeviceType>
 template <class Scalar, class DeviceType, class EntityType>
 std::shared_ptr<StructuredSolver<Scalar, EntityType, DeviceType>>
 createStructuredSolver( const std::string &solver_type,
-                        const ArrayLayout<EntityType> &layout )
+                        const ArrayLayout<EntityType> &layout,
+                        const bool is_preconditioner = false )
 {
     if ( "PCG" == solver_type )
-        return std::make_shared<HypreStructPCG<Scalar, EntityType, DeviceType>>(
-            layout );
+        return createHypreStructPCG<Scalar, DeviceType>( layout,
+                                                         is_preconditioner );
     else if ( "GMRES" == solver_type )
-        return std::make_shared<HypreStructGMRES<Scalar, EntityType, DeviceType>>(
-            layout );
+        return createHypreStructGMRES<Scalar, DeviceType>( layout,
+                                                           is_preconditioner );
+    else if ( "BiCGSTAB" == solver_type )
+        return createHypreStructBiCGSTAB<Scalar, DeviceType>(
+            layout, is_preconditioner );
     else if ( "PFMG" == solver_type )
-        return std::make_shared<HypreStructPFMG<Scalar, EntityType, DeviceType>>(
-            layout );
+        return createHypreStructPFMG<Scalar, DeviceType>( layout,
+                                                          is_preconditioner );
     else if ( "SMG" == solver_type )
-        return std::make_shared<HypreStructSMG<Scalar, EntityType, DeviceType>>(
-            layout );
+        return createHypreStructSMG<Scalar, DeviceType>( layout,
+                                                         is_preconditioner );
+    else if ( "Jacobi" == solver_type )
+        return createHypreStructJacobi<Scalar, DeviceType>( layout,
+                                                            is_preconditioner );
+    else if ( "Diagonal" == solver_type )
+        return createHypreStructDiagonal<Scalar, DeviceType>(
+            layout, is_preconditioner );
     else
         throw std::runtime_error( "Invalid solver type" );
 }

--- a/src/Cajita_StructuredSolver.hpp
+++ b/src/Cajita_StructuredSolver.hpp
@@ -75,9 +75,9 @@ class StructuredSolver
             _lower = {static_cast<HYPRE_Int>( global_space.min( Dim::K ) ),
                       static_cast<HYPRE_Int>( global_space.min( Dim::J ) ),
                       static_cast<HYPRE_Int>( global_space.min( Dim::I ) )};
-            _upper = {static_cast<HYPRE_Int>( global_space.max( Dim::K ) ) - 1,
-                      static_cast<HYPRE_Int>( global_space.max( Dim::J ) ) - 1,
-                      static_cast<HYPRE_Int>( global_space.max( Dim::I ) ) - 1};
+            _upper = {static_cast<HYPRE_Int>( global_space.max( Dim::K ) - 1 ),
+                      static_cast<HYPRE_Int>( global_space.max( Dim::J ) - 1 ),
+                      static_cast<HYPRE_Int>( global_space.max( Dim::I ) - 1 )};
             error = HYPRE_StructGridSetExtents( _grid, _lower.data(),
                                                 _upper.data() );
             checkHypreError( error );
@@ -104,8 +104,8 @@ class StructuredSolver
                                           global_space.extent( Dim::J ),
                                           global_space.extent( Dim::K )} );
             auto vector_values =
-                createView<double, Kokkos::LayoutRight, Kokkos::HostSpace>(
-                    "vector_values", reorder_space );
+                createView<HYPRE_Complex, Kokkos::LayoutRight,
+                           Kokkos::HostSpace>( "vector_values", reorder_space );
             Kokkos::deep_copy( vector_values, 0.0 );
 
             error = HYPRE_StructVectorCreate( _comm, _grid, &_b );
@@ -224,7 +224,7 @@ class StructuredSolver
             {owned_space.extent( Dim::I ), owned_space.extent( Dim::J ),
              owned_space.extent( Dim::K ), _stencil_size} );
         auto a_values =
-            createView<double, Kokkos::LayoutRight, Kokkos::HostSpace>(
+            createView<HYPRE_Complex, Kokkos::LayoutRight, Kokkos::HostSpace>(
                 "a_values", reorder_space );
         Kokkos::deep_copy( a_values, owned_mirror );
 
@@ -317,7 +317,7 @@ class StructuredSolver
                                       owned_space.extent( Dim::J ),
                                       owned_space.extent( Dim::K ), 1} );
         auto vector_values =
-            createView<double, Kokkos::LayoutRight, Kokkos::HostSpace>(
+            createView<HYPRE_Complex, Kokkos::LayoutRight, Kokkos::HostSpace>(
                 "vector_values", reorder_space );
         Kokkos::deep_copy( vector_values, b_mirror );
 
@@ -819,11 +819,12 @@ class HypreStructPFMG : public StructuredSolver<Scalar, EntityType, DeviceType>
     }
 
     // Set relaxation type.
+    //
     // 0 - Jacobi
     // 1 - Weighted Jacobi (default)
     // 2 - Red/Black Gauss-Seidel (symmetric: RB pre-relaxation, BR
-    // post-relaxation) 3 - Red/Black Gauss-Seidel (nonsymmetric: RB pre- and
     // post-relaxation)
+    // 3 - Red/Black Gauss-Seidel (nonsymmetric: RB pre- and post-relaxation)
     void setRelaxType( const int relax_type )
     {
         auto error = HYPRE_StructPFMGSetRelaxType( _solver, relax_type );

--- a/unit_test/tstStructuredSolver.hpp
+++ b/unit_test/tstStructuredSolver.hpp
@@ -36,8 +36,8 @@ void poissonTest()
     // Create the global grid.
     double cell_size = 0.1;
     std::vector<bool> is_dim_periodic = {true,true,true};
-    std::vector<double> global_low_corner = {-1.0, -1.0, -1.0 };
-    std::vector<double> global_high_corner = { 1.0, 1.0, 1.0 };
+    std::vector<double> global_low_corner = {-1.0, -2.0, -1.0 };
+    std::vector<double> global_high_corner = { 1.0, 1.0, 0.5 };
     auto global_grid = createGlobalGrid( MPI_COMM_WORLD,
                                          partitioner,
                                          is_dim_periodic,
@@ -60,7 +60,7 @@ void poissonTest()
 
     // Create a solver.
     auto solver =
-        createStructuredSolver( "PCG", *vector_layout, TEST_DEVICE() );
+        createStructuredSolver<double,TEST_DEVICE>( "PCG", *vector_layout );
 
     // Create a 7-point 3d laplacian stencil.
     std::vector<std::array<int,3> > stencil =

--- a/unit_test/tstStructuredSolver.hpp
+++ b/unit_test/tstStructuredSolver.hpp
@@ -28,14 +28,14 @@ namespace Test
 {
 
 //---------------------------------------------------------------------------//
-void poissonTest()
+void poissonTest( const std::string& solver_type, const std::string& precond_type )
 {
     // Let MPI compute the partitioning for this test.
     UniformDimPartitioner partitioner;
 
     // Create the global grid.
     double cell_size = 0.1;
-    std::vector<bool> is_dim_periodic = {true,true,true};
+    std::vector<bool> is_dim_periodic = {false,false,false};
     std::vector<double> global_low_corner = {-1.0, -2.0, -1.0 };
     std::vector<double> global_high_corner = { 1.0, 1.0, 0.5 };
     auto global_grid = createGlobalGrid( MPI_COMM_WORLD,
@@ -60,7 +60,7 @@ void poissonTest()
 
     // Create a solver.
     auto solver =
-        createStructuredSolver<double,TEST_DEVICE>( "PCG", *vector_layout );
+        createStructuredSolver<double,TEST_DEVICE>( solver_type, *vector_layout );
 
     // Create a 7-point 3d laplacian stencil.
     std::vector<std::array<int,3> > stencil =
@@ -77,20 +77,32 @@ void poissonTest()
         createExecutionPolicy( owned_space, TEST_EXECSPACE() ),
         KOKKOS_LAMBDA( const int i, const int j, const int k ){
             entry_view(i,j,k,0) = -6.0;
-            entry_view(i,j,k,1) = 0.0;
-            entry_view(i,j,k,2) = 0.0;
-            entry_view(i,j,k,3) = 0.0;
-            entry_view(i,j,k,4) = 0.0;
-            entry_view(i,j,k,5) = 0.0;
-            entry_view(i,j,k,6) = 0.0;
+            entry_view(i,j,k,1) = 1.0;
+            entry_view(i,j,k,2) = 1.0;
+            entry_view(i,j,k,3) = 1.0;
+            entry_view(i,j,k,4) = 1.0;
+            entry_view(i,j,k,5) = 1.0;
+            entry_view(i,j,k,6) = 1.0;
         } );
+
     solver->setMatrixValues( *matrix_entries );
 
     // Set the tolerance.
-    solver->setTolerance( 1.0e-4 );
+    solver->setTolerance( 1.0e-8 );
+
+    // Set the maximum iterations.
+    solver->setMaxIter( 2000 );
 
     // Set the print level.
     solver->setPrintLevel( 2 );
+
+    // Create a preconditioner.
+    if ( "none" != precond_type )
+    {
+        auto preconditioner =
+            createStructuredSolver<double,TEST_DEVICE>( precond_type, *vector_layout, true );
+        solver->setPreconditioner( preconditioner );
+    }
 
     // Setup the problem.
     solver->setup();
@@ -98,9 +110,26 @@ void poissonTest()
     // Solve the problem.
     solver->solve( *rhs, *lhs );
 
+    // Create a jacobi solver reference for comparison.
+    auto lhs_ref = createArray<double,TEST_DEVICE>( "lhs_ref", vector_layout );
+    ArrayOp::assign( *lhs_ref, 0.0, Own() );
+
+    auto jacobi_ref =
+        createStructuredSolver<double,TEST_DEVICE>( "Jacobi", *vector_layout );
+
+    jacobi_ref->setMatrixStencil( stencil );
+    jacobi_ref->setMatrixValues( *matrix_entries );
+    jacobi_ref->setTolerance( 1.0e-12 );
+    jacobi_ref->setPrintLevel( 2 );
+    jacobi_ref->setup();
+    jacobi_ref->solve( *rhs, *lhs_ref );
+
     // Check the results.
+    double epsilon = 1.0e-3;
     auto lhs_host = Kokkos::create_mirror_view_and_copy(
         Kokkos::HostSpace(), lhs->view() );
+    auto lhs_ref_host = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), lhs_ref->view() );
     for ( int i = owned_space.min(Dim::I);
           i < owned_space.max(Dim::I);
           ++i )
@@ -110,7 +139,7 @@ void poissonTest()
             for ( int k = owned_space.min(Dim::K);
                   k < owned_space.max(Dim::K);
                   ++k )
-                EXPECT_EQ( lhs_host(i,j,k,0), -1.0 / 6.0 );
+                EXPECT_NEAR( lhs_host(i,j,k,0), lhs_ref_host(i,j,k,0), epsilon );
 
     // Setup the problem again. We would need to do this if we changed the
     // matrix entries.
@@ -121,9 +150,15 @@ void poissonTest()
     ArrayOp::assign( *lhs, 0.0, Own() );
     solver->solve( *rhs, *lhs );
 
+    // Compute another reference solution.
+    ArrayOp::assign( *lhs_ref, 0.0, Own() );
+    jacobi_ref->solve( *rhs, *lhs_ref );
+
     // Check the results again
     lhs_host = Kokkos::create_mirror_view_and_copy(
         Kokkos::HostSpace(), lhs->view() );
+    lhs_ref_host = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), lhs_ref->view() );
     for ( int i = owned_space.min(Dim::I);
           i < owned_space.max(Dim::I);
           ++i )
@@ -133,15 +168,60 @@ void poissonTest()
             for ( int k = owned_space.min(Dim::K);
                   k < owned_space.max(Dim::K);
                   ++k )
-                EXPECT_EQ( lhs_host(i,j,k,0), -1.0 / 3.0 );
+                EXPECT_NEAR( lhs_host(i,j,k,0), lhs_ref_host(i,j,k,0), epsilon );
 }
 
 //---------------------------------------------------------------------------//
 // RUN TESTS
 //---------------------------------------------------------------------------//
-TEST( structured_solver, poisson_test )
+TEST( structured_solver, pcg_none_test )
 {
-    poissonTest();
+    poissonTest( "PCG", "none" );
+}
+
+TEST( structured_solver, gmres_none_test )
+{
+    poissonTest( "GMRES", "none" );
+}
+
+TEST( structured_solver, bicgstab_none_test )
+{
+    poissonTest( "BiCGSTAB", "none" );
+}
+
+TEST( structured_solver, pfmg_none_test )
+{
+    poissonTest( "PFMG", "none" );
+}
+
+TEST( structured_solver, pcg_diag_test )
+{
+    poissonTest( "PCG", "Diagonal" );
+}
+
+TEST( structured_solver, gmres_diag_test )
+{
+    poissonTest( "GMRES", "Diagonal" );
+}
+
+TEST( structured_solver, bicgstab_diag_test )
+{
+    poissonTest( "BiCGSTAB", "Diagonal" );
+}
+
+TEST( structured_solver, pcg_jacobi_test )
+{
+    poissonTest( "PCG", "Jacobi" );
+}
+
+TEST( structured_solver, gmres_jacobi_test )
+{
+    poissonTest( "GMRES", "Jacobi" );
+}
+
+TEST( structured_solver, bicgstab_jacobi_test )
+{
+    poissonTest( "BiCGSTAB", "Jacobi" );
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
This PR does a few important things:

- Cleans the way that data is copied from `Cajita::Array` to the Hypre internal representation. This will make life way easier when we do GPU-enabled and avoids user-written kernels
- Adds a new interface for preconditioning. A solver can now be designated as a preconditioner and solvers can be assigned a preconditioner.
- All additional functions have been exposed in the solver subclasses for setting/getting parameters
- Builders have been added to allow for easy construction of subclasses directly. This will make life easier for people who know which solver/preconditioner they want to use which allows for setting/getting additional parameters not in the base interface without casting.
- Adds access to BiCGSTAB solver
- Adds access to Jacobi solver/preconditioner
- Adds access to Diagonal preconditioner