### PR TITLE
Edge Entity

### DIFF
--- a/src/Cajita_Block.cpp
+++ b/src/Cajita_Block.cpp
@@ -642,6 +642,144 @@ IndexSpace<3> Block::sharedIndexSpace( Ghost t1, Face<Dim::K> t2, const int i,
 }
 
 //---------------------------------------------------------------------------//
+template <>
+IndexSpace<3> Block::indexSpace( Own t1, Edge<Dim::I> t2, Local t3 ) const
+{
+    return edgeIndexSpace( t1, t2, t3 );
+}
+
+//---------------------------------------------------------------------------//
+template <>
+IndexSpace<3> Block::indexSpace( Ghost t1, Edge<Dim::I> t2, Local t3 ) const
+{
+    return edgeIndexSpace( t1, t2, t3 );
+}
+
+//---------------------------------------------------------------------------//
+template <>
+IndexSpace<3> Block::indexSpace( Own t1, Edge<Dim::I> t2, Global t3 ) const
+{
+    return edgeIndexSpace( t1, t2, t3 );
+}
+
+//---------------------------------------------------------------------------//
+template <>
+IndexSpace<3> Block::indexSpace( Ghost t1, Edge<Dim::I> t2, Global t3 ) const
+{
+    return edgeIndexSpace( t1, t2, t3 );
+}
+
+//---------------------------------------------------------------------------//
+template <>
+IndexSpace<3> Block::sharedIndexSpace( Own t1, Edge<Dim::I> t2, const int i,
+                                       const int j, const int k,
+                                       const int hw ) const
+{
+    return edgeSharedIndexSpace( t1, t2, i, j, k, hw );
+}
+
+//---------------------------------------------------------------------------//
+template <>
+IndexSpace<3> Block::sharedIndexSpace( Ghost t1, Edge<Dim::I> t2, const int i,
+                                       const int j, const int k,
+                                       const int hw ) const
+{
+    return edgeSharedIndexSpace( t1, t2, i, j, k, hw );
+}
+
+//---------------------------------------------------------------------------//
+template <>
+IndexSpace<3> Block::indexSpace( Own t1, Edge<Dim::J> t2, Local t3 ) const
+{
+    return edgeIndexSpace( t1, t2, t3 );
+}
+
+//---------------------------------------------------------------------------//
+template <>
+IndexSpace<3> Block::indexSpace( Ghost t1, Edge<Dim::J> t2, Local t3 ) const
+{
+    return edgeIndexSpace( t1, t2, t3 );
+}
+
+//---------------------------------------------------------------------------//
+template <>
+IndexSpace<3> Block::indexSpace( Own t1, Edge<Dim::J> t2, Global t3 ) const
+{
+    return edgeIndexSpace( t1, t2, t3 );
+}
+
+//---------------------------------------------------------------------------//
+template <>
+IndexSpace<3> Block::indexSpace( Ghost t1, Edge<Dim::J> t2, Global t3 ) const
+{
+    return edgeIndexSpace( t1, t2, t3 );
+}
+
+//---------------------------------------------------------------------------//
+template <>
+IndexSpace<3> Block::sharedIndexSpace( Own t1, Edge<Dim::J> t2, const int i,
+                                       const int j, const int k,
+                                       const int hw ) const
+{
+    return edgeSharedIndexSpace( t1, t2, i, j, k, hw );
+}
+
+//---------------------------------------------------------------------------//
+template <>
+IndexSpace<3> Block::sharedIndexSpace( Ghost t1, Edge<Dim::J> t2, const int i,
+                                       const int j, const int k,
+                                       const int hw ) const
+{
+    return edgeSharedIndexSpace( t1, t2, i, j, k, hw );
+}
+
+//---------------------------------------------------------------------------//
+template <>
+IndexSpace<3> Block::indexSpace( Own t1, Edge<Dim::K> t2, Local t3 ) const
+{
+    return edgeIndexSpace( t1, t2, t3 );
+}
+
+//---------------------------------------------------------------------------//
+template <>
+IndexSpace<3> Block::indexSpace( Ghost t1, Edge<Dim::K> t2, Local t3 ) const
+{
+    return edgeIndexSpace( t1, t2, t3 );
+}
+
+//---------------------------------------------------------------------------//
+template <>
+IndexSpace<3> Block::indexSpace( Own t1, Edge<Dim::K> t2, Global t3 ) const
+{
+    return edgeIndexSpace( t1, t2, t3 );
+}
+
+//---------------------------------------------------------------------------//
+template <>
+IndexSpace<3> Block::indexSpace( Ghost t1, Edge<Dim::K> t2, Global t3 ) const
+{
+    return edgeIndexSpace( t1, t2, t3 );
+}
+
+//---------------------------------------------------------------------------//
+template <>
+IndexSpace<3> Block::sharedIndexSpace( Own t1, Edge<Dim::K> t2, const int i,
+                                       const int j, const int k,
+                                       const int hw ) const
+{
+    return edgeSharedIndexSpace( t1, t2, i, j, k, hw );
+}
+
+//---------------------------------------------------------------------------//
+template <>
+IndexSpace<3> Block::sharedIndexSpace( Ghost t1, Edge<Dim::K> t2, const int i,
+                                       const int j, const int k,
+                                       const int hw ) const
+{
+    return edgeSharedIndexSpace( t1, t2, i, j, k, hw );
+}
+
+//---------------------------------------------------------------------------//
 // Get the global index space of the owned cells.
 template <class EntityType>
 IndexSpace<3> Block::globalIndexSpace( Own, EntityType ) const
@@ -905,6 +1043,234 @@ IndexSpace<3> Block::faceSharedIndexSpace( Ghost, Face<Dir>, const int off_i,
 }
 
 //---------------------------------------------------------------------------//
+// Get the local index space of the owned Dir-direction edges.
+template <int Dir>
+IndexSpace<3> Block::edgeIndexSpace( Own, Edge<Dir>, Local ) const
+{
+    // Compute the lower bound.
+    std::array<long, 3> min;
+    for ( int d = 0; d < 3; ++d )
+        min[d] = ( _global_grid->domain().isPeriodic( d ) ||
+                   _global_grid->dimBlockId( d ) > 0 )
+                     ? _halo_cell_width
+                     : 0;
+
+    // Compute the upper bound.
+    std::array<long, 3> max;
+    for ( int d = 0; d < 3; ++d )
+    {
+        if ( Dir == d )
+        {
+            max[d] = min[d] + _global_grid->ownedNumCell( d );
+        }
+        else
+        {
+            max[d] = ( _global_grid->domain().isPeriodic( d ) ||
+                       _global_grid->dimBlockId( d ) <
+                           _global_grid->dimNumBlock( d ) - 1 )
+                         ? min[d] + _global_grid->ownedNumCell( d )
+                         : min[d] + _global_grid->ownedNumCell( d ) + 1;
+        }
+    }
+
+    return IndexSpace<3>( min, max );
+}
+
+//---------------------------------------------------------------------------//
+// Get the local index space of the owned and ghosted Dir-direction edges.
+template <int Dir>
+IndexSpace<3> Block::edgeIndexSpace( Ghost, Edge<Dir>, Local ) const
+{
+    // Compute the size.
+    std::array<long, 3> size;
+    for ( int d = 0; d < 3; ++d )
+    {
+        if ( Dir == d )
+        {
+            size[d] = _global_grid->ownedNumCell( d );
+        }
+        else
+        {
+            size[d] = _global_grid->ownedNumCell( d ) + 1;
+        }
+    }
+
+    for ( int d = 0; d < 3; ++d )
+    {
+        // Add the lower halo.
+        if ( _global_grid->domain().isPeriodic( d ) ||
+             _global_grid->dimBlockId( d ) > 0 )
+            size[d] += _halo_cell_width;
+
+        // Add the upper halo.
+        if ( _global_grid->domain().isPeriodic( d ) ||
+             _global_grid->dimBlockId( d ) <
+                 _global_grid->dimNumBlock( d ) - 1 )
+            size[d] += _halo_cell_width;
+    }
+
+    return IndexSpace<3>( size );
+}
+
+//---------------------------------------------------------------------------//
+// Get the global index space of the owned nodes.
+template <int Dir>
+IndexSpace<3> Block::edgeIndexSpace( Own t1, Edge<Dir> t2, Global ) const
+{
+    return globalIndexSpace( t1, t2 );
+}
+
+//---------------------------------------------------------------------------//
+// Get the global index space of the owned and ghosted nodes.
+template <int Dir>
+IndexSpace<3> Block::edgeIndexSpace( Ghost t1, Edge<Dir> t2, Global ) const
+{
+    return globalIndexSpace( t1, t2 );
+}
+
+//---------------------------------------------------------------------------//
+// Given a relative set of indices of a neighbor get the set of local
+// Dir-direction edge indices we own that we share with that neighbor to use
+// as ghosts.
+template <int Dir>
+IndexSpace<3> Block::edgeSharedIndexSpace( Own, Edge<Dir>, const int off_i,
+                                           const int off_j, const int off_k,
+                                           const int halo_width ) const
+{
+    // If we got the default halo width of -1 this means we want to use the
+    // default of the entire halo.
+    int hw = ( -1 == halo_width ) ? _halo_cell_width : halo_width;
+
+    // Check that the offsets are valid.
+    if ( off_i < -1 || 1 < off_i || off_j < -1 || 1 < off_j || off_k < -1 ||
+         1 < off_k )
+        throw std::logic_error( "Neighbor indices out of bounds" );
+
+    // Check that the requested halo width is valid.
+    if ( hw > _halo_cell_width )
+        throw std::logic_error( "Requested halo width larger than block halo" );
+
+    // Check to see if this is a valid neighbor. If not, return a shared space
+    // of size 0.
+    if ( neighborRank( off_i, off_j, off_k ) < 0 )
+        return IndexSpace<3>( {0, 0, 0}, {0, 0, 0} );
+
+    // Wrap the indices.
+    std::array<long, 3> nid = {off_i, off_j, off_k};
+
+    // Get the owned local index space.
+    auto owned_space = indexSpace( Own(), Edge<Dir>(), Local() );
+
+    // Compute the lower bound.
+    std::array<long, 3> min;
+    for ( int d = 0; d < 3; ++d )
+    {
+        // Lower neighbor.
+        if ( -1 == nid[d] )
+            min[d] = owned_space.min( d );
+
+        // Middle neighbor.
+        else if ( 0 == nid[d] )
+            min[d] = owned_space.min( d );
+
+        // Upper neighbor.
+        else if ( 1 == nid[d] )
+            min[d] = owned_space.max( d ) - hw;
+    }
+
+    // Compute the upper bound.
+    std::array<long, 3> max;
+    for ( int d = 0; d < 3; ++d )
+    {
+        // Lower neighbor.
+        if ( -1 == nid[d] )
+            max[d] = ( Dir == d ) ? owned_space.min( d ) + hw
+                                  : owned_space.min( d ) + hw + 1;
+
+        // Middle neighbor.
+        else if ( 0 == nid[d] )
+            max[d] = owned_space.max( d );
+
+        // Upper neighbor.
+        else if ( 1 == nid[d] )
+            max[d] = owned_space.max( d );
+    }
+
+    return IndexSpace<3>( min, max );
+}
+
+//---------------------------------------------------------------------------//
+// Given a relative set of indices of a neighbor get set of local
+// Dir-direction edge indices owned by that neighbor that are shared with us
+// to use as ghosts.
+template <int Dir>
+IndexSpace<3> Block::edgeSharedIndexSpace( Ghost, Edge<Dir>, const int off_i,
+                                           const int off_j, const int off_k,
+                                           const int halo_width ) const
+{
+    // If we got the default halo width of -1 this means we want to use the
+    // default of the entire halo.
+    int hw = ( -1 == halo_width ) ? _halo_cell_width : halo_width;
+
+    // Check that the offsets are valid.
+    if ( off_i < -1 || 1 < off_i || off_j < -1 || 1 < off_j || off_k < -1 ||
+         1 < off_k )
+        throw std::logic_error( "Neighbor indices out of bounds" );
+
+    // Check that the requested halo width is valid.
+    if ( hw > _halo_cell_width )
+        throw std::logic_error( "Requested halo width larger than block halo" );
+
+    // Check to see if this is a valid neighbor. If not, return a shared space
+    // of size 0.
+    if ( neighborRank( off_i, off_j, off_k ) < 0 )
+        return IndexSpace<3>( {0, 0, 0}, {0, 0, 0} );
+
+    // Wrap the indices.
+    std::array<long, 3> nid = {off_i, off_j, off_k};
+
+    // Get the owned local index space.
+    auto owned_space = indexSpace( Own(), Edge<Dir>(), Local() );
+
+    // Compute the lower bound.
+    std::array<long, 3> min;
+    for ( int d = 0; d < 3; ++d )
+    {
+        // Lower neighbor.
+        if ( -1 == nid[d] )
+            min[d] = owned_space.min( d ) - hw;
+
+        // Middle neighbor
+        else if ( 0 == nid[d] )
+            min[d] = owned_space.min( d );
+
+        // Upper neighbor.
+        else if ( 1 == nid[d] )
+            min[d] = owned_space.max( d );
+    }
+
+    // Compute the upper bound.
+    std::array<long, 3> max;
+    for ( int d = 0; d < 3; ++d )
+    {
+        // Lower neighbor.
+        if ( -1 == nid[d] )
+            max[d] = owned_space.min( d );
+
+        // Middle neighbor
+        else if ( 0 == nid[d] )
+            max[d] = owned_space.max( d );
+
+        // Upper neighbor.
+        else if ( 1 == nid[d] )
+            max[d] = ( Dir == d ) ? owned_space.max( d ) + hw
+                                  : owned_space.max( d ) + hw + 1;
+    }
+
+    return IndexSpace<3>( min, max );
+}
+
+//---------------------------------------------------------------------------//
 // Global indexing explicit instantiations
 //---------------------------------------------------------------------------//
 template IndexSpace<3> Block::globalIndexSpace( Own, Cell ) const;
@@ -986,6 +1352,69 @@ template IndexSpace<3> Block::faceSharedIndexSpace( Own, Face<Dim::K>,
                                                     const int ) const;
 
 template IndexSpace<3> Block::faceSharedIndexSpace( Ghost, Face<Dim::K>,
+                                                    const int, const int,
+                                                    const int,
+                                                    const int ) const;
+
+//---------------------------------------------------------------------------//
+// Edge indexing explicit instantiations
+//---------------------------------------------------------------------------//
+template IndexSpace<3> Block::edgeIndexSpace( Own, Edge<Dim::I>, Local ) const;
+
+template IndexSpace<3> Block::edgeIndexSpace( Own, Edge<Dim::I>, Global ) const;
+
+template IndexSpace<3> Block::edgeIndexSpace( Ghost, Edge<Dim::I>,
+                                              Local ) const;
+
+template IndexSpace<3> Block::edgeIndexSpace( Ghost, Edge<Dim::I>,
+                                              Global ) const;
+
+template IndexSpace<3> Block::edgeIndexSpace( Own, Edge<Dim::J>, Local ) const;
+
+template IndexSpace<3> Block::edgeIndexSpace( Own, Edge<Dim::J>, Global ) const;
+
+template IndexSpace<3> Block::edgeIndexSpace( Ghost, Edge<Dim::J>,
+                                              Local ) const;
+
+template IndexSpace<3> Block::edgeIndexSpace( Ghost, Edge<Dim::J>,
+                                              Global ) const;
+
+template IndexSpace<3> Block::edgeIndexSpace( Own, Edge<Dim::K>, Local ) const;
+
+template IndexSpace<3> Block::edgeIndexSpace( Own, Edge<Dim::K>, Global ) const;
+
+template IndexSpace<3> Block::edgeIndexSpace( Ghost, Edge<Dim::K>,
+                                              Local ) const;
+
+template IndexSpace<3> Block::edgeIndexSpace( Ghost, Edge<Dim::K>,
+                                              Global ) const;
+
+template IndexSpace<3> Block::edgeSharedIndexSpace( Own, Edge<Dim::I>,
+                                                    const int, const int,
+                                                    const int,
+                                                    const int ) const;
+
+template IndexSpace<3> Block::edgeSharedIndexSpace( Ghost, Edge<Dim::I>,
+                                                    const int, const int,
+                                                    const int,
+                                                    const int ) const;
+
+template IndexSpace<3> Block::edgeSharedIndexSpace( Own, Edge<Dim::J>,
+                                                    const int, const int,
+                                                    const int,
+                                                    const int ) const;
+
+template IndexSpace<3> Block::edgeSharedIndexSpace( Ghost, Edge<Dim::J>,
+                                                    const int, const int,
+                                                    const int,
+                                                    const int ) const;
+
+template IndexSpace<3> Block::edgeSharedIndexSpace( Own, Edge<Dim::K>,
+                                                    const int, const int,
+                                                    const int,
+                                                    const int ) const;
+
+template IndexSpace<3> Block::edgeSharedIndexSpace( Ghost, Edge<Dim::K>,
                                                     const int, const int,
                                                     const int,
                                                     const int ) const;

--- a/src/Cajita_Block.hpp
+++ b/src/Cajita_Block.hpp
@@ -103,6 +103,27 @@ class Block
                                         const int off_j, const int off_k,
                                         const int halo_width ) const;
 
+    // Get the edge index space of the block.
+    template <int Dir>
+    IndexSpace<3> edgeIndexSpace( Own, Edge<Dir>, Local ) const;
+    template <int Dir>
+    IndexSpace<3> edgeIndexSpace( Own, Edge<Dir>, Global ) const;
+    template <int Dir>
+    IndexSpace<3> edgeIndexSpace( Ghost, Edge<Dir>, Local ) const;
+    template <int Dir>
+    IndexSpace<3> edgeIndexSpace( Ghost, Edge<Dir>, Global ) const;
+
+    // Given a relative set of indices of a neighbor get the set of local
+    // edge indices shared with that neighbor in the given decomposition.
+    template <int Dir>
+    IndexSpace<3> edgeSharedIndexSpace( Own, Edge<Dir>, const int off_,
+                                        const int off_j, const int off_k,
+                                        const int halo_width ) const;
+    template <int Dir>
+    IndexSpace<3> edgeSharedIndexSpace( Ghost, Edge<Dir>, const int off_i,
+                                        const int off_j, const int off_k,
+                                        const int halo_width ) const;
+
   private:
     std::shared_ptr<GlobalGrid> _global_grid;
     int _halo_cell_width;

--- a/src/Cajita_GlobalGrid.cpp
+++ b/src/Cajita_GlobalGrid.cpp
@@ -197,6 +197,33 @@ int GlobalGrid::globalNumEntity( Face<Dim::K>, const int dim ) const
 }
 
 //---------------------------------------------------------------------------//
+// Get the global number of I-edges in a given dimension.
+template <>
+int GlobalGrid::globalNumEntity( Edge<Dim::I>, const int dim ) const
+{
+    return ( Dim::I == dim ) ? globalNumEntity( Cell(), dim )
+                             : globalNumEntity( Node(), dim );
+}
+
+//---------------------------------------------------------------------------//
+// Get the global number of J-edges in a given dimension.
+template <>
+int GlobalGrid::globalNumEntity( Edge<Dim::J>, const int dim ) const
+{
+    return ( Dim::J == dim ) ? globalNumEntity( Cell(), dim )
+                             : globalNumEntity( Node(), dim );
+}
+
+//---------------------------------------------------------------------------//
+// Get the global number of K-edges in a given dimension.
+template <>
+int GlobalGrid::globalNumEntity( Edge<Dim::K>, const int dim ) const
+{
+    return ( Dim::K == dim ) ? globalNumEntity( Cell(), dim )
+                             : globalNumEntity( Node(), dim );
+}
+
+//---------------------------------------------------------------------------//
 // Get the owned number of cells in a given dimension.
 int GlobalGrid::ownedNumCell( const int dim ) const
 {

--- a/src/Cajita_Types.hpp
+++ b/src/Cajita_Types.hpp
@@ -64,6 +64,28 @@ struct Face<Dim::K>
 {
 };
 
+// Mesh edge tags.
+template <int D>
+struct Edge;
+
+// I-edge tag.
+template <>
+struct Edge<Dim::I>
+{
+};
+
+// J-edge tag.
+template <>
+struct Edge<Dim::J>
+{
+};
+
+// K-edge tag.
+template <>
+struct Edge<Dim::K>
+{
+};
+
 //---------------------------------------------------------------------------//
 // Decomposition tags.
 //---------------------------------------------------------------------------//

--- a/unit_test/tstGlobalGrid.hpp
+++ b/unit_test/tstGlobalGrid.hpp
@@ -68,6 +68,90 @@ void gridTest( const std::vector<bool>& is_dim_periodic )
 
     }
 
+    // Number of I faces
+    if ( is_dim_periodic[Dim::I] )
+        EXPECT_EQ( global_grid->globalNumEntity( Face<Dim::I>(), Dim::I ),
+                   global_num_cell[Dim::I] );
+    else
+        EXPECT_EQ( global_grid->globalNumEntity( Face<Dim::I>(), Dim::I ),
+                   global_num_cell[Dim::I] + 1 );
+    EXPECT_EQ( global_grid->globalNumEntity( Face<Dim::I>(), Dim::J ),
+               global_num_cell[Dim::J] );
+    EXPECT_EQ( global_grid->globalNumEntity( Face<Dim::I>(), Dim::K ),
+               global_num_cell[Dim::K] );
+
+    // Number of J faces.
+    EXPECT_EQ( global_grid->globalNumEntity( Face<Dim::J>(), Dim::I ),
+               global_num_cell[Dim::I] );
+    if ( is_dim_periodic[Dim::I] )
+        EXPECT_EQ( global_grid->globalNumEntity( Face<Dim::J>(), Dim::J ),
+                   global_num_cell[Dim::J] );
+    else
+        EXPECT_EQ( global_grid->globalNumEntity( Face<Dim::J>(), Dim::J ),
+                   global_num_cell[Dim::J] + 1 );
+    EXPECT_EQ( global_grid->globalNumEntity( Face<Dim::J>(), Dim::K ),
+               global_num_cell[Dim::K] );
+
+    // Number of K faces.
+    EXPECT_EQ( global_grid->globalNumEntity( Face<Dim::K>(), Dim::I ),
+               global_num_cell[Dim::I] );
+    EXPECT_EQ( global_grid->globalNumEntity( Face<Dim::K>(), Dim::J ),
+               global_num_cell[Dim::J] );
+    if ( is_dim_periodic[Dim::I] )
+        EXPECT_EQ( global_grid->globalNumEntity( Face<Dim::K>(), Dim::K ),
+                   global_num_cell[Dim::K] );
+    else
+        EXPECT_EQ( global_grid->globalNumEntity( Face<Dim::K>(), Dim::K ),
+                   global_num_cell[Dim::K] + 1 );
+
+    // Number of I edges
+    EXPECT_EQ( global_grid->globalNumEntity( Edge<Dim::I>(), Dim::I ),
+               global_num_cell[Dim::I] );
+    if ( is_dim_periodic[Dim::J] )
+        EXPECT_EQ( global_grid->globalNumEntity( Edge<Dim::I>(), Dim::J ),
+                   global_num_cell[Dim::J] );
+    else
+        EXPECT_EQ( global_grid->globalNumEntity( Edge<Dim::I>(), Dim::J ),
+                   global_num_cell[Dim::J] + 1 );
+    if ( is_dim_periodic[Dim::K] )
+        EXPECT_EQ( global_grid->globalNumEntity( Edge<Dim::I>(), Dim::K ),
+                   global_num_cell[Dim::K] );
+    else
+        EXPECT_EQ( global_grid->globalNumEntity( Edge<Dim::I>(), Dim::K ),
+                   global_num_cell[Dim::K] + 1 );
+
+    // Number of J edges
+    if ( is_dim_periodic[Dim::I] )
+        EXPECT_EQ( global_grid->globalNumEntity( Edge<Dim::J>(), Dim::I ),
+                   global_num_cell[Dim::I] );
+    else
+        EXPECT_EQ( global_grid->globalNumEntity( Edge<Dim::J>(), Dim::I ),
+                   global_num_cell[Dim::I] + 1 );
+    EXPECT_EQ( global_grid->globalNumEntity( Edge<Dim::J>(), Dim::J ),
+               global_num_cell[Dim::J] );
+    if ( is_dim_periodic[Dim::K] )
+        EXPECT_EQ( global_grid->globalNumEntity( Edge<Dim::J>(), Dim::K ),
+                   global_num_cell[Dim::K] );
+    else
+        EXPECT_EQ( global_grid->globalNumEntity( Edge<Dim::J>(), Dim::K ),
+                   global_num_cell[Dim::K] + 1 );
+
+    // Number of K edges
+    if ( is_dim_periodic[Dim::I] )
+        EXPECT_EQ( global_grid->globalNumEntity( Edge<Dim::K>(), Dim::I ),
+                   global_num_cell[Dim::I] );
+    else
+        EXPECT_EQ( global_grid->globalNumEntity( Edge<Dim::K>(), Dim::I ),
+                   global_num_cell[Dim::I] + 1 );
+    if ( is_dim_periodic[Dim::J] )
+        EXPECT_EQ( global_grid->globalNumEntity( Edge<Dim::K>(), Dim::J ),
+                   global_num_cell[Dim::J] );
+    else
+        EXPECT_EQ( global_grid->globalNumEntity( Edge<Dim::K>(), Dim::J ),
+                   global_num_cell[Dim::J] + 1 );
+    EXPECT_EQ( global_grid->globalNumEntity( Edge<Dim::K>(), Dim::K ),
+               global_num_cell[Dim::K] );
+
     // Check the partitioning. The grid communicator has a Cartesian topology.
     int comm_size;
     MPI_Comm_size( MPI_COMM_WORLD, &comm_size );


### PR DESCRIPTION
Adding support for edge entities. This was the last entity type in the library domain model not implemented in the code. Edges will be needed in a number of Discretizations including higher-order schemes and implementations of curl operators.

This PR adds an edge entity implementation similar to that of the face entity implementation where a integer template parameter is used to indicate the orientation of the edge (i.e. `Cajita::Edge<Cajita::Dim::J>`. Edge orientations indicate the direction the edge points (whereas face orientations indicate the direction the face normal points).

All indexing and halo operations are supported for edges.