### PR TITLE
Splines

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ set(HEADERS_PUBLIC
   Cajita_ManualPartitioner.hpp
   Cajita_MpiTraits.hpp
   Cajita_Partitioner.hpp
+  Cajita_Splines.hpp
   Cajita_Types.hpp
   Cajita_UniformDimPartitioner.hpp
   )

--- a/src/Cajita_Splines.hpp
+++ b/src/Cajita_Splines.hpp
@@ -1,0 +1,353 @@
+#ifndef CAJITA_SPLINES_HPP
+#define CAJITA_SPLINES_HPP
+
+#include <Kokkos_Core.hpp>
+
+#include <cmath>
+
+namespace Cajita
+{
+//---------------------------------------------------------------------------//
+// B-Spline interface for uniform grids.
+//---------------------------------------------------------------------------//
+template <int Order>
+struct Spline;
+
+//---------------------------------------------------------------------------//
+// Linear. Defined on the primal grid.
+template <>
+struct Spline<1>
+{
+    // Order.
+    static constexpr int order = 1;
+
+    // The number of non-zero knots in the spline.
+    static constexpr int num_knot = 2;
+
+    /*!
+      \brief Map a physical location to the logical space of the primal grid in
+      a single dimension. \param xp The coordinate to map to the logical space.
+      \param rdx The inverse of the physical distance between grid locations.
+      \param low_x The physical location of the low corner of the primal
+      grid.
+      \return The coordinate in the logical primal grid space.
+
+      \note Casting this result to an integer yields the index at the center
+      of the stencil.
+      \note A linear spline uses the primal grid.
+    */
+    template <class Scalar>
+    KOKKOS_INLINE_FUNCTION static Scalar
+    mapToLogicalGrid( const Scalar xp, const Scalar rdx, const Scalar low_x )
+    {
+        return ( xp - low_x ) * rdx;
+    }
+
+    /*
+      \brief Get the logical space stencil offsets of the spline. The stencil
+      defines the offsets into a grid field about a logical coordinate.
+      \param indices The stencil index offsets.
+    */
+    KOKKOS_INLINE_FUNCTION
+    static void offsets( int indices[num_knot] )
+    {
+        indices[0] = 0;
+        indices[1] = 1;
+    }
+
+    /*!
+      \brief Compute the stencil indices for a given logical space location.
+      \param x0 The coordinate at which to evaluate the spline stencil.
+      \param indices The indices of the stencil.
+    */
+    template <class Scalar>
+    KOKKOS_INLINE_FUNCTION static void stencil( const Scalar x0,
+                                                int indices[num_knot] )
+    {
+        indices[0] = int( x0 );
+        indices[1] = indices[0] + 1;
+    }
+
+    /*!
+      \brief Calculate the value of the spline at all knots.
+      \param x0 The coordinate at which to evaluate the spline in the logical
+      grid space.
+      \param values Basis values at the knots. Ordered from lowest to highest
+      in terms of knot location.
+    */
+    template <typename Scalar>
+    KOKKOS_INLINE_FUNCTION static void value( const Scalar x0,
+                                              Scalar values[num_knot] )
+    {
+        // Knot at i
+        Scalar xn = x0 - int( x0 );
+        values[0] = 1.0 - xn;
+
+        // Knot at i + 1
+        values[1] = xn;
+    }
+
+    /*!
+      \brief Calculate the value of the gradient of the spline in the
+      physical frame.
+      \param x0 The coordinate at which to evaluate the spline in the logical
+      grid space.
+      \param rdx The inverse of the physical distance between grid locations.
+      \param gradients Basis gradient values at the knots in the physical
+      frame. Ordered from lowest to highest in terms of knot location.
+    */
+    template <typename Scalar>
+    KOKKOS_INLINE_FUNCTION static void gradient( const Scalar, const Scalar rdx,
+                                                 Scalar gradients[num_knot] )
+    {
+        // Knot at i.
+        gradients[0] = -rdx;
+
+        // Knot at i + 1;
+        gradients[1] = rdx;
+    }
+};
+
+//---------------------------------------------------------------------------//
+// Quadratic. Defined on the dual grid.
+template <>
+struct Spline<2>
+{
+    // Order.
+    static constexpr int order = 2;
+
+    // The number of non-zero knots in the spline.
+    static constexpr int num_knot = 3;
+
+    /*!
+      \brief Map a physical location to the logical space of the dual grid in a
+      single dimension.
+      \param xp The coordinate to map to the logical space.
+      \param rdx The inverse of the physical distance between grid locations.
+      \param low_x The physical location of the low corner of the dual grid.
+      \return The coordinate in the logical dual grid space.
+
+      \note Casting this result to an integer yields the index at the center
+      of the stencil.
+      \note A quadratic spline uses the dual grid.
+    */
+    template <class Scalar>
+    KOKKOS_INLINE_FUNCTION static Scalar
+    mapToLogicalGrid( const Scalar xp, const Scalar rdx, const Scalar low_x )
+    {
+        return ( xp - low_x ) * rdx + 0.5;
+    }
+
+    /*
+      \brief Get the logical space stencil offsets of the spline. The stencil
+      defines the offsets into a grid field about a logical coordinate.
+      \param indices The stencil index offsets.
+    */
+    KOKKOS_INLINE_FUNCTION
+    static void offsets( int indices[num_knot] )
+    {
+        indices[0] = -1;
+        indices[1] = 0;
+        indices[2] = 1;
+    }
+
+    /*!
+      \brief Compute the stencil indices for a given logical space location.
+      \param x0 The coordinate at which to evaluate the spline stencil.
+      \param indices The indices of the stencil.
+    */
+    template <class Scalar>
+    KOKKOS_INLINE_FUNCTION static void stencil( const Scalar x0,
+                                                int indices[num_knot] )
+    {
+        indices[0] = int( x0 ) - 1;
+        indices[1] = indices[0] + 1;
+        indices[2] = indices[1] + 1;
+    }
+
+    /*!
+       \brief Calculate the value of the spline at all knots.
+       \param x0 The coordinate at which to evaluate the spline in the logical
+       grid space.
+       \param values Basis values at the knots. Ordered from lowest to highest
+       in terms of knot location.
+    */
+    template <typename Scalar>
+    KOKKOS_INLINE_FUNCTION static void value( const Scalar x0,
+                                              Scalar values[num_knot] )
+    {
+        // Constants
+        Scalar nine_eights = 9.0 / 8.0;
+
+        // Knot at i - 1
+        Scalar xn = x0 - int( x0 ) + 0.5;
+        values[0] = 0.5 * xn * xn - 1.5 * xn + nine_eights;
+
+        // Knot at i
+        xn -= 1.0;
+        values[1] = -xn * xn + 0.75;
+
+        // Knot at i + 1
+        xn -= 1.0;
+        values[2] = 0.5 * xn * xn + 1.5 * xn + nine_eights;
+    }
+
+    /*!
+      \brief Calculate the value of the gradient of the spline in the
+      physical frame.
+      \param x0 The coordinate at which to evaluate the spline in the logical
+      grid space.
+      \param rdx The inverse of the physical distance between grid locations.
+      \param gradients Basis gradient values at the knots in the physical
+      frame. Ordered from lowest to highest in terms of knot location.
+    */
+    template <typename Scalar>
+    KOKKOS_INLINE_FUNCTION static void
+    gradient( const Scalar x0, const Scalar rdx, Scalar gradients[num_knot] )
+    {
+        // Knot at i - 1
+        Scalar xn = x0 - int( x0 ) + 0.5;
+        gradients[0] = ( xn - 1.5 ) * rdx;
+
+        // Knot at i
+        xn -= 1.0;
+        gradients[1] = ( -2.0 * xn ) * rdx;
+
+        // Knot at i + 1
+        xn -= 1.0;
+        gradients[2] = ( xn + 1.5 ) * rdx;
+    }
+};
+
+//---------------------------------------------------------------------------//
+// Cubic. Defined on the primal grid.
+template <>
+struct Spline<3>
+{
+    // Order.
+    static constexpr int order = 3;
+
+    // The number of non-zero knots in the spline.
+    static constexpr int num_knot = 4;
+
+    /*!
+      \brief Map a physical location to the logical space of the primal grid in
+      a single dimension. \param xp The coordinate to map to the logical space.
+      \param rdx The inverse of the physical distance between grid locations.
+      \param low_x The physical location of the low corner of the primal
+      grid.
+      \return The coordinate in the logical primal grid space.
+
+      \note Casting this result to an integer yields the index at the center
+      of the stencil.
+      \note A cubic spline uses the primal grid.
+    */
+    template <class Scalar>
+    KOKKOS_INLINE_FUNCTION static Scalar
+    mapToLogicalGrid( const Scalar xp, const Scalar rdx, const Scalar low_x )
+    {
+        return ( xp - low_x ) * rdx;
+    }
+
+    /*
+      \brief Get the logical space stencil offsets of the spline. The stencil
+      defines the offsets into a grid field about a logical coordinate.
+      \param indices The stencil index offsets.
+    */
+    KOKKOS_INLINE_FUNCTION
+    static void offsets( int indices[num_knot] )
+    {
+        indices[0] = -1;
+        indices[1] = 0;
+        indices[2] = 1;
+        indices[3] = 2;
+    }
+
+    /*!
+      \brief Compute the stencil indices for a given logical space location.
+      \param x0 The coordinate at which to evaluate the spline stencil.
+      \param indices The indices of the stencil.
+    */
+    template <class Scalar>
+    KOKKOS_INLINE_FUNCTION static void stencil( const Scalar x0,
+                                                int indices[num_knot] )
+    {
+        indices[0] = int( x0 ) - 1;
+        indices[1] = indices[0] + 1;
+        indices[2] = indices[1] + 1;
+        indices[3] = indices[2] + 1;
+    }
+
+    /*!
+       \brief Calculate the value of the spline at all knots.
+       \param x0 The coordinate at which to evaluate the spline in the logical
+       grid space.
+       \param values Basis values at the knots. Ordered from lowest to highest
+       in terms of knot location.
+    */
+    template <typename Scalar>
+    KOKKOS_INLINE_FUNCTION static void value( const Scalar x0,
+                                              Scalar values[num_knot] )
+    {
+        // Constants
+        Scalar one_sixth = 1.0 / 6.0;
+        Scalar two_thirds = one_sixth * 4.0;
+        Scalar four_thirds = two_thirds * 2.0;
+
+        // Knot at i - 1
+        Scalar xn = x0 - int( x0 ) + 1.0;
+        Scalar xn2 = xn * xn;
+        values[0] = -xn * xn2 * one_sixth + xn2 - 2.0 * xn + four_thirds;
+
+        // Knot at i
+        xn -= 1.0;
+        xn2 = xn * xn;
+        values[1] = 0.5 * xn * xn2 - xn2 + two_thirds;
+
+        // Knot at i + 1
+        xn -= 1.0;
+        xn2 = xn * xn;
+        values[2] = -0.5 * xn * xn2 - xn2 + two_thirds;
+
+        // Knot at i + 2
+        xn -= 1.0;
+        xn2 = xn * xn;
+        values[3] = xn * xn2 * one_sixth + xn2 + 2.0 * xn + four_thirds;
+    }
+
+    /*!
+      \brief Calculate the value of the gradient of the spline in the
+      physical frame.
+      \param x0 The coordinate at which to evaluate the spline in the logical
+      grid space.
+      \param rdx The inverse of the physical distance between grid locations.
+      \param gradients Basis gradient values at the knots in the physical
+      frame. Ordered from lowest to highest in terms of knot location.
+    */
+    template <typename Scalar>
+    KOKKOS_INLINE_FUNCTION static void
+    gradient( const Scalar x0, const Scalar rdx, Scalar gradients[num_knot] )
+    {
+        // Knot at i - 1
+        Scalar xn = x0 - int( x0 ) + 1.0;
+        gradients[0] = ( -0.5 * xn * xn + 2.0 * xn - 2.0 ) * rdx;
+
+        // Knot at i
+        xn -= 1.0;
+        gradients[1] = ( 1.5 * xn * xn - 2.0 * xn ) * rdx;
+
+        // Knot at i + 1
+        xn -= 1.0;
+        gradients[2] = ( -1.5 * xn * xn - 2.0 * xn ) * rdx;
+
+        // Knot at i + 2
+        xn -= 1.0;
+        gradients[3] = ( 0.5 * xn * xn + 2.0 * xn + 2.0 ) * rdx;
+    }
+};
+
+//---------------------------------------------------------------------------//
+
+} // end namespace Cajita
+
+#endif // end CAJITA_SPLINES_HPP

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -57,6 +57,7 @@ endmacro()
 
 set(SERIAL_TESTS
   IndexSpace
+  Splines
   )
 
 set(MPI_TESTS

--- a/unit_test/tstSplines.hpp
+++ b/unit_test/tstSplines.hpp
@@ -1,0 +1,205 @@
+#include <Cajita_Splines.hpp>
+
+#include <vector>
+
+#include <gtest/gtest.h>
+
+using namespace Cajita;
+
+namespace Test
+{
+//---------------------------------------------------------------------------//
+// TESTS
+//---------------------------------------------------------------------------//
+TEST( cajita_splines, linear_spline_test )
+{
+    // Check partition of unity for the linear spline.
+    double xp = -1.4;
+    double low_x = -3.43;
+    double dx = 0.27;
+    double rdx = 1.0 / dx;
+    double values[2];
+
+    double x0 = Spline<1>::mapToLogicalGrid( xp, rdx, low_x );
+    Spline<1>::value( x0, values );
+    double sum = 0.0;
+    for ( auto x : values ) sum += x;
+    EXPECT_FLOAT_EQ( sum, 1.0 );
+
+    xp = 2.1789;
+    x0 = Spline<1>::mapToLogicalGrid( xp, rdx, low_x );
+    Spline<1>::value( x0, values );
+    sum = 0.0;
+    for ( auto x : values ) sum += x;
+    EXPECT_FLOAT_EQ( sum, 1.0 );
+
+    xp = low_x + 5 * dx;
+    x0 = Spline<1>::mapToLogicalGrid( xp, rdx, low_x );
+    Spline<1>::value( x0, values );
+    sum = 0.0;
+    for ( auto x : values ) sum += x;
+    EXPECT_FLOAT_EQ( sum, 1.0 );
+
+    // Check the stencil by putting a point in the center of a primal cell.
+    int cell_id = 4;
+    xp = low_x + (cell_id + 0.5) * dx;
+    x0 = Spline<1>::mapToLogicalGrid( xp, rdx, low_x );
+    int offsets[2];
+    Spline<1>::offsets( offsets );
+    EXPECT_EQ( int(x0) + offsets[0], cell_id );
+    EXPECT_EQ( int(x0) + offsets[1], cell_id + 1);
+
+    int stencil[2];
+    Spline<1>::stencil( x0, stencil );
+    EXPECT_EQ( stencil[0], cell_id );
+    EXPECT_EQ( stencil[1], cell_id + 1);
+
+    // Check the interpolation of a function.
+    auto grid_func = [=]( const double x ){ return 4.32*x - 0.31; };
+    double field[Spline<1>::num_knot];
+    field[0] = grid_func( low_x + cell_id * dx );
+    field[1] = grid_func( low_x + (cell_id + 1) * dx );
+    Spline<1>::value( x0, values );
+    double field_xp = field[0] * values[0] + field[1] * values[1];
+    EXPECT_FLOAT_EQ( field_xp, grid_func(xp) );
+
+    // Check the derivative of a function.
+    Spline<1>::gradient( x0, rdx, values );
+    double field_grad = field[0] * values[0] + field[1] * values[1];
+    auto grid_deriv = [=]( const double ){ return 4.32; };
+    EXPECT_FLOAT_EQ( field_grad, grid_deriv(xp) );
+}
+
+TEST( cajita_splines, quadratic_spline_test )
+{
+    // Check partition of unity for the quadratic spline.
+    double xp = -1.4;
+    double low_x = -3.43;
+    double dx = 0.27;
+    double rdx = 1.0 / dx;
+    double values[3];
+
+    double x0 = Spline<2>::mapToLogicalGrid( xp, rdx, low_x );
+    Spline<2>::value( x0, values );
+    double sum = 0.0;
+    for ( auto x : values ) sum += x;
+    EXPECT_FLOAT_EQ( sum, 1.0 );
+
+    xp = 2.1789;
+    x0 = Spline<2>::mapToLogicalGrid( xp, rdx, low_x );
+    Spline<2>::value( x0, values );
+    sum = 0.0;
+    for ( auto x : values ) sum += x;
+    EXPECT_FLOAT_EQ( sum, 1.0 );
+
+    xp = low_x + 5 * dx;
+    x0 = Spline<2>::mapToLogicalGrid( xp, rdx, low_x );
+    Spline<2>::value( x0, values );
+    sum = 0.0;
+    for ( auto x : values ) sum += x;
+    EXPECT_FLOAT_EQ( sum, 1.0 );
+
+    // Check the stencil by putting a point in the center of a dual cell (on a
+    // node).
+    int node_id = 4;
+    xp = low_x + (node_id + 0.25) * dx;
+    x0 = Spline<2>::mapToLogicalGrid( xp, rdx, low_x );
+    int offsets[3];
+    Spline<2>::offsets( offsets );
+    EXPECT_EQ( int(x0) + offsets[0], node_id - 1);
+    EXPECT_EQ( int(x0) + offsets[1], node_id);
+    EXPECT_EQ( int(x0) + offsets[2], node_id + 1);
+
+    int stencil[3];
+    Spline<2>::stencil( x0, stencil );
+    EXPECT_EQ( stencil[0], node_id - 1);
+    EXPECT_EQ( stencil[1], node_id);
+    EXPECT_EQ( stencil[2], node_id + 1);
+
+    // Check the interpolation of a function.
+    auto grid_func = [=]( const double x ){ return 4.32*x - 0.31; };
+    double field[Spline<2>::num_knot];
+    field[0] = grid_func( low_x + (node_id - 1) * dx );
+    field[1] = grid_func( low_x + node_id * dx );
+    field[2] = grid_func( low_x + (node_id + 1) * dx );
+    Spline<2>::value( x0, values );
+    double field_xp = field[0] * values[0] + field[1] * values[1] +
+                      field[2] * values[2];
+    EXPECT_FLOAT_EQ( field_xp, grid_func(xp) );
+
+    // Check the derivative of a function.
+    Spline<2>::gradient( x0, rdx, values );
+    double field_grad = field[0] * values[0] + field[1] * values[1] +
+                      field[2] * values[2];
+    auto grid_deriv = [=]( const double ){ return 4.32; };
+    EXPECT_FLOAT_EQ( field_grad, grid_deriv(xp) );
+}
+
+TEST( cajita_splines, cubic_spline_test )
+{
+    // Check partition of unity for the cubic spline.
+    double xp = -1.4;
+    double low_x = -3.43;
+    double dx = 0.27;
+    double rdx = 1.0 / dx;
+    double values[4];
+
+    double x0 = Spline<3>::mapToLogicalGrid( xp, rdx, low_x );
+    Spline<3>::value( x0, values );
+    double sum = 0.0;
+    for ( auto x : values ) sum += x;
+    EXPECT_FLOAT_EQ( sum, 1.0 );
+
+    xp = 2.1789;
+    x0 = Spline<3>::mapToLogicalGrid( xp, rdx, low_x );
+    Spline<3>::value( x0, values );
+    sum = 0.0;
+    for ( auto x : values ) sum += x;
+    EXPECT_FLOAT_EQ( sum, 1.0 );
+
+    xp = low_x + 5 * dx;
+    x0 = Spline<3>::mapToLogicalGrid( xp, rdx, low_x );
+    Spline<3>::value( x0, values );
+    sum = 0.0;
+    for ( auto x : values ) sum += x;
+    EXPECT_FLOAT_EQ( sum, 1.0 );
+
+    // Check the stencil by putting a point in the center of a primal cell.
+    int cell_id = 4;
+    xp = low_x + (cell_id + 0.75) * dx;
+    x0 = Spline<3>::mapToLogicalGrid( xp, rdx, low_x );
+    int offsets[4];
+    Spline<3>::offsets( offsets );
+    EXPECT_EQ( int(x0) + offsets[0], cell_id - 1 );
+    EXPECT_EQ( int(x0) + offsets[1], cell_id );
+    EXPECT_EQ( int(x0) + offsets[2], cell_id + 1 );
+    EXPECT_EQ( int(x0) + offsets[3], cell_id + 2 );
+
+    int stencil[4];
+    Spline<3>::stencil( x0, stencil );
+    EXPECT_EQ( stencil[0], cell_id - 1 );
+    EXPECT_EQ( stencil[1], cell_id );
+    EXPECT_EQ( stencil[2], cell_id + 1 );
+    EXPECT_EQ( stencil[3], cell_id + 2 );
+
+    // Check the interpolation of a function.
+    auto grid_func = [=]( const double x ){ return 4.32*x - 0.31; };
+    double field[Spline<3>::num_knot];
+    field[0] = grid_func( low_x + (cell_id - 1) * dx );
+    field[1] = grid_func( low_x + cell_id * dx );
+    field[2] = grid_func( low_x + (cell_id + 1) * dx );
+    field[3] = grid_func( low_x + (cell_id + 2) * dx );
+    Spline<3>::value( x0, values );
+    double field_xp = field[0] * values[0] + field[1] * values[1] +
+                      field[2] * values[2] + field[3] * values[3];
+    EXPECT_FLOAT_EQ( field_xp, grid_func(xp) );
+
+    // Check the derivative of a function.
+    Spline<3>::gradient( x0, rdx, values );
+    double field_grad = field[0] * values[0] + field[1] * values[1] +
+                      field[2] * values[2] + field[3] * values[3];
+    auto grid_deriv = [=]( const double ){ return 4.32; };
+    EXPECT_FLOAT_EQ( field_grad, grid_deriv(xp) );
+}
+
+} // end namespace Test


### PR DESCRIPTION
Adds a cardinal spline function interface with linear, quadratic, and cubic implementations which will be used for P2G (particle-to-grid) and G2P (grid-to-particle) implementations. 

- The interface allows a user to map a value to the logical grid (dual or primal depending on the spline type). The logical grid result gives the local entity index at the center of the stencil
- Users can get the deposition stencil in terms of offsets from the center of the stencil or in terms of local block indices
- Values and gradients can be evaluated
- The splines are agnostic in terms of which entity type is being projected to - one only needs to low corner of the grid with respect to that given entity
- These splines are only for uniform grids.