### PR TITLE
Particle/Grid Interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 Cajita
 
-A small library for computations on uniform grids
+A small library for computations on Cartesian grids

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,10 +7,12 @@ set(HEADERS_PUBLIC
   Cajita_GlobalMesh.hpp
   Cajita_Halo.hpp
   Cajita_IndexSpace.hpp
+  Cajita_Interpolation.hpp
   Cajita_LocalMesh.hpp
   Cajita_ManualPartitioner.hpp
   Cajita_MpiTraits.hpp
   Cajita_Partitioner.hpp
+  Cajita_PointSet.hpp
   Cajita_Splines.hpp
   Cajita_Types.hpp
   Cajita_UniformDimPartitioner.hpp

--- a/src/Cajita.hpp
+++ b/src/Cajita.hpp
@@ -20,10 +20,12 @@
 #include <Cajita_GlobalMesh.hpp>
 #include <Cajita_Halo.hpp>
 #include <Cajita_IndexSpace.hpp>
+#include <Cajita_Interpolation.hpp>
 #include <Cajita_LocalMesh.hpp>
 #include <Cajita_ManualPartitioner.hpp>
 #include <Cajita_MpiTraits.hpp>
 #include <Cajita_Partitioner.hpp>
+#include <Cajita_PointSet.hpp>
 #include <Cajita_Types.hpp>
 #include <Cajita_UniformDimPartitioner.hpp>
 #include <Cajita_Version.hpp>

--- a/src/Cajita_Halo.hpp
+++ b/src/Cajita_Halo.hpp
@@ -183,7 +183,7 @@ class Halo
       other communication routines.
     */
     template <class Array_t>
-    void gather( const Array_t &array, const int mpi_tag )
+    void gather( const Array_t &array, const int mpi_tag ) const
     {
         // Check that the array type is valid.
         static_assert(
@@ -273,7 +273,7 @@ class Halo
       other communication routines.
     */
     template <class Array_t>
-    void scatter( const Array_t &array, const int mpi_tag )
+    void scatter( const Array_t &array, const int mpi_tag ) const
     {
         // Check that the array type is valid.
         static_assert(

--- a/src/Cajita_Interpolation.hpp
+++ b/src/Cajita_Interpolation.hpp
@@ -1,0 +1,702 @@
+/****************************************************************************
+ * Copyright (c) 2019 by the Cajita authors                                 *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Cajita library. Cajita is distributed under a   *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef CAJITA_INTERPOLATION_HPP
+#define CAJITA_INTERPOLATION_HPP
+
+#include <Cajita_Array.hpp>
+#include <Cajita_Halo.hpp>
+#include <Cajita_PointSet.hpp>
+#include <Cajita_Types.hpp>
+
+#include <Kokkos_Core.hpp>
+#include <Kokkos_ScatterView.hpp>
+
+#include <memory>
+
+namespace Cajita
+{
+//---------------------------------------------------------------------------//
+// Point-to-Grid
+//---------------------------------------------------------------------------//
+/*!
+  \brief Local Point-to-Grid interpolation.
+
+  \tparam PointEvalFunctor Functor type used to evaluate the interpolated data
+  for a given point at a given entity.
+
+  \tparam ArrayScalar The scalar type used for the interpolated data.
+
+  \tparam MeshScalar The scalar type used for the geometry/interpolation data.
+
+  \tparam EntityType The entitytype to which the points will interpolate.
+
+  \tparam SplineOrder The order of spline interpolation to use.
+
+  \tparam DeviceType The device type to use for interplation
+
+  \tparam ArrayParams Parameters for the array type.
+
+  \param functor A functor that interpolates from a given point to a given
+  entity.
+
+  \param point_set The point set to use for interpolation.
+
+  \param halo The halo associated with the grid array. This hallo will be used
+  to scatter the interpolated data.
+
+  \param array The grid array to which the point data will be interpolated.
+*/
+template <class PointEvalFunctor, class ArrayScalar, class MeshScalar,
+          class EntityType, int SplineOrder, class DeviceType,
+          class... ArrayParams>
+void p2g(
+    const PointEvalFunctor &functor,
+    const PointSet<MeshScalar, EntityType, SplineOrder, DeviceType> &point_set,
+    const Halo<ArrayScalar, DeviceType> &halo,
+    Array<ArrayScalar, EntityType, UniformMesh<MeshScalar>, ArrayParams...>
+        &array )
+{
+    using array_type =
+        Array<ArrayScalar, EntityType, UniformMesh<MeshScalar>, ArrayParams...>;
+    static_assert(
+        std::is_same<DeviceType, typename array_type::device_type>::value,
+        "Mismatching points/array device types." );
+
+    using execution_space = typename DeviceType::execution_space;
+
+    // Create a scatter view of the array.
+    auto array_view = array.view();
+    auto array_sv = Kokkos::Experimental::create_scatter_view( array_view );
+
+    // Loop over points and interpolate to the grid.
+    Kokkos::parallel_for(
+        "p2g", Kokkos::RangePolicy<execution_space>( 0, point_set.num_point ),
+        KOKKOS_LAMBDA( const int p ) {
+            // Create a local scatter result.
+            ArrayScalar result[PointEvalFunctor::value_count];
+
+            // Access the scatter view.
+            auto array_access = array_sv.access();
+
+            // Loop over the point stencil and evaluate the functor at each
+            // entity in the stencil and apply each stencil result to the
+            // array.
+            for ( int i = 0; i < point_set.ns; ++i )
+                for ( int j = 0; j < point_set.ns; ++j )
+                    for ( int k = 0; k < point_set.ns; ++k )
+                    {
+                        functor( point_set, p, i, j, k, result );
+
+                        for ( int d = 0; d < PointEvalFunctor::value_count;
+                              ++d )
+                            array_access( point_set.stencil( p, i, Dim::I ),
+                                          point_set.stencil( p, j, Dim::J ),
+                                          point_set.stencil( p, k, Dim::K ),
+                                          d ) += result[d];
+                    }
+        } );
+    Kokkos::Experimental::contribute( array_view, array_sv );
+
+    // Scatter interpolation contributions in the halo back to their owning
+    // ranks.
+    halo.scatter( array, 4321 );
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Point-to-grid scalar value functor.
+
+  Interpolates a scalar function from points to entities with a given
+  multiplier such that:
+
+  f_ijk = multiplier * \sum_p weight_{pijk} * f_p
+
+  Note that a functor implements the interpolation contribution between a
+  single point, indexed with a local p index, and a single entity, indexed
+  with local ijk indices. A single, potentially multi-dimensional result is
+  provided as the contribution.
+*/
+template <class ViewType>
+struct ScalarValueP2G
+{
+    static constexpr int value_count = 1;
+    using value_type = typename ViewType::value_type;
+
+    ViewType _x;
+    value_type _multiplier;
+
+    ScalarValueP2G( const ViewType &x, const value_type multiplier )
+        : _x( x )
+        , _multiplier( multiplier )
+    {
+        static_assert( 1 == ViewType::Rank, "View must be of scalars" );
+    }
+
+    template <class PointSetType>
+    KOKKOS_INLINE_FUNCTION void
+    operator()( const PointSetType &point_set, const int p, const int i,
+                const int j, const int k, value_type *result ) const
+    {
+        result[0] = _multiplier * _x( p ) * point_set.value( p, i, Dim::I ) *
+                    point_set.value( p, j, Dim::J ) *
+                    point_set.value( p, k, Dim::K );
+    }
+};
+
+template <class ViewType>
+ScalarValueP2G<ViewType>
+createScalarValueP2G( const ViewType &x,
+                      const typename ViewType::value_type &multiplier )
+{
+    return ScalarValueP2G<ViewType>( x, multiplier );
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Point-to-grid vector value functor.
+
+  Interpolates a vector function from points to entities with a given
+  multiplier such that:
+
+  f_{ijkd} = multiplier * \sum_p weight_{pijk} * f_{pd}
+
+  Note that a functor implements the interpolation contribution between a
+  single point, indexed with a local p index, and a single entity, indexed
+  with local ijk indices. A single, potentially multi-dimensional result is
+  provided as the contribution.
+*/
+template <class ViewType>
+struct VectorValueP2G
+{
+    static constexpr int value_count = 3;
+    using value_type = typename ViewType::value_type;
+
+    ViewType _x;
+    value_type _multiplier;
+
+    VectorValueP2G( const ViewType &x, const value_type multiplier )
+        : _x( x )
+        , _multiplier( multiplier )
+    {
+        static_assert( 2 == ViewType::Rank, "View must be of vectors" );
+    }
+
+    template <class PointSetType>
+    KOKKOS_INLINE_FUNCTION void
+    operator()( const PointSetType &point_set, const int p, const int i,
+                const int j, const int k, value_type *result ) const
+    {
+        value_type weight = _multiplier * point_set.value( p, i, Dim::I ) *
+                            point_set.value( p, j, Dim::J ) *
+                            point_set.value( p, k, Dim::K );
+        for ( int d = 0; d < 3; ++d )
+            result[d] = weight * _x( p, d );
+    }
+};
+
+template <class ViewType>
+VectorValueP2G<ViewType>
+createVectorValueP2G( const ViewType &x,
+                      const typename ViewType::value_type &multiplier )
+{
+    return VectorValueP2G<ViewType>( x, multiplier );
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Point-to-grid scalar gradient functor.
+
+  Interpolates the gradient of a scalar function from points to entities with
+  a given multiplier such that:
+
+  f_{ijkd} = multiplier * \sum_p grad_weight_{pijkd} * f_p
+
+  Note that a functor implements the interpolation contribution between a
+  single point, indexed with a local p index, and a single entity, indexed
+  with local ijk indices. A single, potentially multi-dimensional result is
+  provided as the contribution.
+*/
+template <class ViewType>
+struct ScalarGradientP2G
+{
+    static constexpr int value_count = 3;
+    using value_type = typename ViewType::value_type;
+
+    ViewType _x;
+    value_type _multiplier;
+
+    ScalarGradientP2G( const ViewType &x, const value_type multiplier )
+        : _x( x )
+        , _multiplier( multiplier )
+    {
+        static_assert( 1 == ViewType::Rank, "View must be of scalars" );
+    }
+
+    template <class PointSetType>
+    KOKKOS_INLINE_FUNCTION void
+    operator()( const PointSetType &point_set, const int p, const int i,
+                const int j, const int k, value_type *result ) const
+    {
+        auto mx = _multiplier * _x( p );
+        for ( int d = 0; d < 3; ++d )
+            result[d] = mx * point_set.gradient( p, i, j, k, d );
+    }
+};
+
+template <class ViewType>
+ScalarGradientP2G<ViewType>
+createScalarGradientP2G( const ViewType &x,
+                         const typename ViewType::value_type &multiplier )
+{
+    return ScalarGradientP2G<ViewType>( x, multiplier );
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Point-to-grid vector divergence functor.
+
+  Interpolates the divergence of a vector function from points to entities
+  with a given multiplier such that:
+
+  f_ijk = multiplier * \sum_d \sum_p grad_weight_{pijkd} * f_{pd}
+
+  Note that a functor implements the interpolation contribution between a
+  single point, indexed with a local p index, and a single entity, indexed
+  with local ijk indices. A single, potentially multi-dimensional result is
+  provided as the contribution.
+*/
+template <class ViewType>
+struct VectorDivergenceP2G
+{
+    static constexpr int value_count = 1;
+    using value_type = typename ViewType::value_type;
+
+    ViewType _x;
+    value_type _multiplier;
+
+    VectorDivergenceP2G( const ViewType &x, const value_type multiplier )
+        : _x( x )
+        , _multiplier( multiplier )
+    {
+        static_assert( 2 == ViewType::Rank, "View must be of vectors" );
+    }
+
+    template <class PointSetType>
+    KOKKOS_INLINE_FUNCTION void
+    operator()( const PointSetType &point_set, const int p, const int i,
+                const int j, const int k, value_type *result ) const
+    {
+        result[0] = 0;
+        for ( int d = 0; d < 3; ++d )
+            result[0] += _x( p, d ) * point_set.gradient( p, i, j, k, d );
+        result[0] *= _multiplier;
+    }
+};
+
+template <class ViewType>
+VectorDivergenceP2G<ViewType>
+createVectorDivergenceP2G( const ViewType &x,
+                           const typename ViewType::value_type &multiplier )
+{
+    return VectorDivergenceP2G<ViewType>( x, multiplier );
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Point-to-grid tensor divergence functor.
+
+  Interpolates the divergence of a tensor function from points to entities
+  with a given multiplier such that:
+
+  f_ijkm = multiplier * \sum_n \sum_p grad_weight_{pijkn} * f_{pmn}
+
+  Note that a functor implements the interpolation contribution between a
+  single point, indexed with a local p index, and a single entity, indexed
+  with local ijk indices. A single, potentially multi-dimensional result is
+  provided as the contribution.
+*/
+template <class ViewType>
+struct TensorDivergenceP2G
+{
+    static constexpr int value_count = 3;
+    using value_type = typename ViewType::value_type;
+
+    ViewType _x;
+    value_type _multiplier;
+
+    TensorDivergenceP2G( const ViewType &x, const value_type multiplier )
+        : _x( x )
+        , _multiplier( multiplier )
+    {
+        static_assert( 3 == ViewType::Rank, "View must be of tensors" );
+    }
+
+    template <class PointSetType>
+    KOKKOS_INLINE_FUNCTION void
+    operator()( const PointSetType &point_set, const int p, const int i,
+                const int j, const int k, value_type *result ) const
+    {
+        for ( int d = 0; d < 3; ++d )
+            result[d] = 0.0;
+        for ( int d1 = 0; d1 < 3; ++d1 )
+        {
+            auto mg = _multiplier * point_set.gradient( p, i, j, k, d1 );
+            for ( int d0 = 0; d0 < 3; ++d0 )
+                result[d0] += mg * _x( p, d0, d1 );
+        }
+    }
+};
+
+template <class ViewType>
+TensorDivergenceP2G<ViewType>
+createTensorDivergenceP2G( const ViewType &x,
+                           const typename ViewType::value_type &multiplier )
+{
+    return TensorDivergenceP2G<ViewType>( x, multiplier );
+}
+
+//---------------------------------------------------------------------------//
+// Grid-to-Point
+//---------------------------------------------------------------------------//
+/*
+ \brief Local Grid-to-Point interpolation.
+
+  \tparam PointEvalFunctor Functor type used to evaluate the interpolated data
+  for a given point at a given entity.
+
+  \tparam ArrayScalar The scalar type used for the interpolated data.
+
+  \tparam MeshScalar The scalar type used for the geometry/interpolation data.
+
+  \tparam EntityType The entitytype to which the points will interpolate.
+
+  \tparam SplineOrder The order of spline interpolation to use.
+
+  \tparam DeviceType The device type to use for interplation
+
+  \tparam ArrayParams Parameters for the array type.
+
+  \param array The grid array to from the point data will be interpolated.
+
+  \param halo The halo associated with the grid array. This hallo will be used
+  to gather the array data before interpolation.
+
+  \param point_set The point set to use for interpolation.
+
+  \param functor A functor that interpolates from a given entity to a given
+  point.
+*/
+template <class PointEvalFunctor, class ArrayScalar, class MeshScalar,
+          class EntityType, int SplineOrder, class DeviceType,
+          class... ArrayParams>
+void g2p(
+    const Array<ArrayScalar, EntityType, UniformMesh<MeshScalar>,
+                ArrayParams...> &array,
+    const Halo<ArrayScalar, DeviceType> &halo,
+    const PointSet<MeshScalar, EntityType, SplineOrder, DeviceType> &point_set,
+    const PointEvalFunctor &functor )
+{
+    using array_type =
+        Array<ArrayScalar, EntityType, UniformMesh<MeshScalar>, ArrayParams...>;
+    static_assert(
+        std::is_same<DeviceType, typename array_type::device_type>::value,
+        "Mismatching points/array device types." );
+
+    using execution_space = typename DeviceType::execution_space;
+
+    // Gather data into the halo before interpolating.
+    halo.gather( array, 4321 );
+
+    // Get a view of the array data.
+    auto array_view = array.view();
+
+    // Loop over points and interpolate from the grid.
+    Kokkos::parallel_for(
+        "g2p", Kokkos::RangePolicy<execution_space>( 0, point_set.num_point ),
+        KOKKOS_LAMBDA( const int p ) {
+            // Create local gather values.
+            ArrayScalar values[PointEvalFunctor::value_count];
+
+            // Loop over the point stencil and interpolate the grid data to
+            // the points.
+            for ( int i = 0; i < point_set.ns; ++i )
+                for ( int j = 0; j < point_set.ns; ++j )
+                    for ( int k = 0; k < point_set.ns; ++k )
+                    {
+                        for ( int d = 0; d < PointEvalFunctor::value_count;
+                              ++d )
+                            values[d] = array_view(
+                                point_set.stencil( p, i, Dim::I ),
+                                point_set.stencil( p, j, Dim::J ),
+                                point_set.stencil( p, k, Dim::K ), d );
+
+                        functor( point_set, p, i, j, k, values );
+                    }
+        } );
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Grid-to-point scalar value functor.
+
+  Interpolates a scalar function from entities to points with a given
+  multiplier such that:
+
+  f_p = multiplier * \sum_{ijk} weight_{pijk} * f_{ijk}
+
+  Note that a functor implements the interpolation contribution between a
+  single point, indexed with a local p index, and a single entity, indexed
+  with local ijk indices. A single, potentially multi-dimensional result is
+  provided as the contribution.
+*/
+template <class ViewType>
+struct ScalarValueG2P
+{
+    static constexpr int value_count = 1;
+    using value_type = typename ViewType::value_type;
+
+    ViewType _x;
+    value_type _multiplier;
+
+    ScalarValueG2P( const ViewType &x, const value_type multiplier )
+        : _x( x )
+        , _multiplier( multiplier )
+    {
+        static_assert( 1 == ViewType::Rank, "View must be of scalars" );
+    }
+
+    template <class PointSetType>
+    KOKKOS_INLINE_FUNCTION void
+    operator()( const PointSetType &point_set, const int p, const int i,
+                const int j, const int k, const value_type *values ) const
+    {
+        _x( p ) += _multiplier * values[0] * point_set.value( p, i, Dim::I ) *
+                   point_set.value( p, j, Dim::J ) *
+                   point_set.value( p, k, Dim::K );
+    }
+};
+
+template <class ViewType>
+ScalarValueG2P<ViewType>
+createScalarValueG2P( const ViewType &x,
+                      const typename ViewType::value_type &multiplier )
+{
+    return ScalarValueG2P<ViewType>( x, multiplier );
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Grid-to-point vector value functor.
+
+  Interpolates a vector function from entities to points with a given
+  multiplier such that:
+
+  f_{pd} = multiplier * \sum_{ijk} weight_{pijk} * f_{ijkd}
+
+  Note that a functor implements the interpolation contribution between a
+  single point, indexed with a local p index, and a single entity, indexed
+  with local ijk indices. A single, potentially multi-dimensional result is
+  provided as the contribution.
+*/
+template <class ViewType>
+struct VectorValueG2P
+{
+    static constexpr int value_count = 3;
+    using value_type = typename ViewType::value_type;
+
+    ViewType _x;
+    value_type _multiplier;
+
+    VectorValueG2P( const ViewType &x, const value_type multiplier )
+        : _x( x )
+        , _multiplier( multiplier )
+    {
+        static_assert( 2 == ViewType::Rank, "View must be of vectors" );
+    }
+
+    template <class PointSetType>
+    KOKKOS_INLINE_FUNCTION void
+    operator()( const PointSetType &point_set, const int p, const int i,
+                const int j, const int k, const value_type *values ) const
+    {
+        value_type weight = _multiplier * point_set.value( p, i, Dim::I ) *
+                            point_set.value( p, j, Dim::J ) *
+                            point_set.value( p, k, Dim::K );
+        for ( int d = 0; d < 3; ++d )
+            _x( p, d ) += weight * values[d];
+    }
+};
+
+template <class ViewType>
+VectorValueG2P<ViewType>
+createVectorValueG2P( const ViewType &x,
+                      const typename ViewType::value_type &multiplier )
+{
+    return VectorValueG2P<ViewType>( x, multiplier );
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Grid-to-point scalar gradient functor.
+
+  Interpolates the gradient of a scalar function from entities to points with
+  a given multiplier such that:
+
+  f_{pd} = multiplier * \sum_{ijk} grad_weight_{pijkd} * f_{ijk}
+
+  Note that a functor implements the interpolation contribution between a
+  single point, indexed with a local p index, and a single entity, indexed
+  with local ijk indices. A single, potentially multi-dimensional result is
+  provided as the contribution.
+*/
+template <class ViewType>
+struct ScalarGradientG2P
+{
+    static constexpr int value_count = 1;
+    using value_type = typename ViewType::value_type;
+
+    ViewType _x;
+    value_type _multiplier;
+
+    ScalarGradientG2P( const ViewType &x, const value_type multiplier )
+        : _x( x )
+        , _multiplier( multiplier )
+    {
+        static_assert( 2 == ViewType::Rank, "View must be of vectors" );
+    }
+
+    template <class PointSetType>
+    KOKKOS_INLINE_FUNCTION void
+    operator()( const PointSetType &point_set, const int p, const int i,
+                const int j, const int k, const value_type *values ) const
+    {
+        auto mx = _multiplier * values[0];
+        for ( int d = 0; d < 3; ++d )
+            _x( p, d ) += mx * point_set.gradient( p, i, j, k, d );
+    }
+};
+
+template <class ViewType>
+ScalarGradientG2P<ViewType>
+createScalarGradientG2P( const ViewType &x,
+                         const typename ViewType::value_type &multiplier )
+{
+    return ScalarGradientG2P<ViewType>( x, multiplier );
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Grid-to-point vector gradient functor.
+
+  Interpolates the gradient of a vector function from entities to points with
+  a given multiplier such that:
+
+  f_{pmn} = multiplier * \sum_{ijk} grad_weight_{pijkm} * f_{ijkn}
+
+  Note that a functor implements the interpolation contribution between a
+  single point, indexed with a local p index, and a single entity, indexed
+  with local ijk indices. A single, potentially multi-dimensional result is
+  provided as the contribution.
+*/
+template <class ViewType>
+struct VectorGradientG2P
+{
+    static constexpr int value_count = 3;
+    using value_type = typename ViewType::value_type;
+
+    ViewType _x;
+    value_type _multiplier;
+
+    VectorGradientG2P( const ViewType &x, const value_type multiplier )
+        : _x( x )
+        , _multiplier( multiplier )
+    {
+        static_assert( 3 == ViewType::Rank, "View must be of tensors" );
+    }
+
+    template <class PointSetType>
+    KOKKOS_INLINE_FUNCTION void
+    operator()( const PointSetType &point_set, const int p, const int i,
+                const int j, const int k, const value_type *values ) const
+    {
+        for ( int d0 = 0; d0 < 3; ++d0 )
+        {
+            auto mg = _multiplier * point_set.gradient( p, i, j, k, d0 );
+            for ( int d1 = 0; d1 < 3; ++d1 )
+                _x( p, d0, d1 ) += mg * values[d1];
+        }
+    }
+};
+
+template <class ViewType>
+VectorGradientG2P<ViewType>
+createVectorGradientG2P( const ViewType &x,
+                         const typename ViewType::value_type &multiplier )
+{
+    return VectorGradientG2P<ViewType>( x, multiplier );
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Grid-to-point vector value functor.
+
+  Interpolates the divergence of a vector function from entities to points
+  with a given multiplier such that:
+
+  f_p = multiplier * \sum_d \sum_{ijk} grad_weight_{pijkd} * f_{ijkd}
+
+  Note that a functor implements the interpolation contribution between a
+  single point, indexed with a local p index, and a single entity, indexed
+  with local ijk indices. A single, potentially multi-dimensional result is
+  provided as the contribution.
+*/
+template <class ViewType>
+struct VectorDivergenceG2P
+{
+    static constexpr int value_count = 3;
+    using value_type = typename ViewType::value_type;
+
+    ViewType _x;
+    value_type _multiplier;
+
+    VectorDivergenceG2P( const ViewType &x, const value_type multiplier )
+        : _x( x )
+        , _multiplier( multiplier )
+    {
+        static_assert( 1 == ViewType::Rank, "View must be of scalars" );
+    }
+
+    template <class PointSetType>
+    KOKKOS_INLINE_FUNCTION void
+    operator()( const PointSetType &point_set, const int p, const int i,
+                const int j, const int k, const value_type *values ) const
+    {
+        value_type v_div = 0.0;
+        for ( int d = 0; d < 3; ++d )
+            v_div += point_set.gradient( p, i, j, k, d ) * values[d];
+        _x( p ) += v_div * _multiplier;
+    }
+};
+
+template <class ViewType>
+VectorDivergenceG2P<ViewType>
+createVectorDivergenceG2P( const ViewType &x,
+                           const typename ViewType::value_type &multiplier )
+{
+    return VectorDivergenceG2P<ViewType>( x, multiplier );
+}
+
+//---------------------------------------------------------------------------//
+
+} // end namespace Cajita
+
+#endif // end CAJITA_INTERPOLATION_HPP

--- a/src/Cajita_PointSet.hpp
+++ b/src/Cajita_PointSet.hpp
@@ -1,0 +1,299 @@
+/****************************************************************************
+ * Copyright (c) 2019 by the Cajita authors                                 *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Cajita library. Cajita is distributed under a   *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#ifndef CAJITA_POINTSET_HPP
+#define CAJITA_POINTSET_HPP
+
+#include <Cajita_Block.hpp>
+#include <Cajita_LocalMesh.hpp>
+#include <Cajita_Splines.hpp>
+
+#include <Kokkos_Core.hpp>
+
+#include <type_traits>
+
+namespace Cajita
+{
+//---------------------------------------------------------------------------//
+/*!
+  \class PointSet
+
+  \brief Evaluation point set with a spline basis.
+
+  \tparam Scalar The scalar type used to represent floating point values.
+
+  \tparam EntityType The type of entity type the spline functions are
+  evaluated at.
+
+  \tparam SplineOrder The order of B-spline to use for the basis.
+
+  \tparam DeviceType The device to use for creating point set data.
+
+  This class defines the point set over points needed for interpolation.
+
+  Each point is centered in a grid stencil defined by the B-spline used for
+  interpolation. The point set contains the point position along with the
+  entities in the stencil and their distances from the points, basis
+  weights, and basis gradients.
+
+  A point set should be regenerated every time points are redistributed and
+  updated every time a new time step is started.
+
+  Point sets are defined for uniform meshes.
+*/
+//---------------------------------------------------------------------------//
+template <class Scalar, class EntityType, int SplineOrder, class DeviceType>
+struct PointSet
+{
+    // Scalar type for geometric operations.
+    using scalar_type = Scalar;
+
+    // Entity type on which the basis is defined.
+    using entity_type = EntityType;
+
+    // Basis
+    static constexpr int spline_order = SplineOrder;
+    using basis_type = Spline<spline_order>;
+
+    // Number of basis values in each dimension.
+    static constexpr int ns = basis_type::num_knot;
+
+    // Kokkos types.
+    using device_type = DeviceType;
+    using execution_space = typename device_type::execution_space;
+    using memory_space = typename device_type::memory_space;
+
+    // Number of points.
+    std::size_t num_point;
+
+    // Number of allocated points.
+    std::size_t num_alloc;
+
+    // Point logical position. (point,dim)
+    Kokkos::View<Scalar * [3], device_type> logical_coords;
+
+    // Point mesh stencil. (point,ns,dim)
+    Kokkos::View<int * [ns][3], device_type> stencil;
+
+    // Point basis values at entities in stencil. (point,ns,dim)
+    Kokkos::View<Scalar * [ns][3], device_type> value;
+
+    // Point basis gradient values at entities in stencil
+    // (point,ni,nj,nk,dim)
+    Kokkos::View<Scalar * [ns][ns][ns][3], device_type> gradient;
+
+    // Mesh uniform cell size.
+    Scalar dx;
+
+    // Inverse uniform mesh cell size.
+    Scalar rdx;
+
+    // Location of the low corner of the local mesh for the given entity
+    // type.
+    Kokkos::Array<Scalar, 3> low_corner;
+};
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Update a point set with new coordinates.
+
+  \tparam PointCoordinates Container type with view traits containing the 3-d
+  point coordinates. Will be indexed as (point,dim).
+
+  \tparam PointSetType The type of point set to update.
+
+  \param points The points over which to build the point set. Will be indexed
+  as (point,dim). All points must be contained within the grid block that was
+  used to generate the point set.
+
+  \param num_point The number of points. This is the size of the first
+  dimension of points. Note that the number of points must less than or equal
+  to the number for which the point set was allocated. If a larger number of
+  points is a needed a new point set must be created to hold the additional
+  memory.
+
+  \param point_set The point set to update.
+*/
+template <class PointCoordinates, class PointSetType>
+void updatePointSet( const PointCoordinates &points,
+                     const std::size_t num_point, PointSetType &point_set )
+{
+    static_assert( std::is_same<typename PointCoordinates::value_type,
+                                typename PointSetType::scalar_type>::value,
+                   "Point coordinate/mesh scalar type mismatch" );
+
+    // Device parameters.
+    using execution_space = typename PointSetType::execution_space;
+
+    // Scalar type
+    using scalar_type = typename PointSetType::scalar_type;
+
+    // Basis parameters.
+    using Basis = typename PointSetType::basis_type;
+    static constexpr int ns = PointSetType::ns;
+
+    // Update the size.
+    if ( num_point > point_set.num_alloc )
+        throw std::logic_error(
+            "Attempted to update point set with more points than allocation" );
+    point_set.num_point = num_point;
+
+    // Update point set value.
+    Kokkos::parallel_for(
+        "updatePointSet",
+        Kokkos::RangePolicy<execution_space>( 0, point_set.num_point ),
+        KOKKOS_LAMBDA( const int p ) {
+            // Map the point coordinates to the logical space of the spline.
+            for ( int d = 0; d < 3; ++d )
+                point_set.logical_coords( p, d ) = Basis::mapToLogicalGrid(
+                    points( p, d ), point_set.rdx, point_set.low_corner[d] );
+
+            // Get the point mesh stencil.
+            int indices[ns];
+            for ( int d = 0; d < 3; ++d )
+            {
+                Basis::stencil( point_set.logical_coords( p, d ), indices );
+                for ( int n = 0; n < ns; ++n )
+                    point_set.stencil( p, n, d ) = indices[n];
+            }
+
+            // Evaluate the spline values at the entities in the stencil.
+            scalar_type basis_values[ns];
+            for ( int d = 0; d < 3; ++d )
+            {
+                Basis::value( point_set.logical_coords( p, d ), basis_values );
+                for ( int n = 0; n < ns; ++n )
+                    point_set.value( p, n, d ) = basis_values[n];
+            }
+
+            // Evaluate the spline gradients at the entities in the stencil.
+            scalar_type basis_gradients[ns];
+            for ( int d = 0; d < 3; ++d )
+            {
+                Basis::gradient( point_set.logical_coords( p, d ),
+                                 point_set.rdx, basis_gradients );
+
+                for ( int i = 0; i < ns; ++i )
+                    for ( int j = 0; j < ns; ++j )
+                        for ( int k = 0; k < ns; ++k )
+                        {
+                            point_set.gradient( p, i, j, k, Dim::I ) =
+                                basis_gradients[i] *
+                                point_set.value( p, j, Dim::J ) *
+                                point_set.value( p, k, Dim::K );
+
+                            point_set.gradient( p, i, j, k, Dim::J ) =
+                                point_set.value( p, i, Dim::I ) *
+                                basis_gradients[j] *
+                                point_set.value( p, k, Dim::K );
+
+                            point_set.gradient( p, i, j, k, Dim::K ) =
+                                point_set.value( p, i, Dim::I ) *
+                                point_set.value( p, j, Dim::J ) *
+                                basis_gradients[k];
+                        }
+            }
+        } );
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Create a point set.
+
+  \tparam PointCoordinates Container type with view traits containing the 3-d
+  point coordinates. Will be indexed as (point,dim). The value type of the
+  coordinates will define the scalar type used to generate the point set.
+
+  \tparam EntityType The type of entity type the spline functions are
+  evaluated at.
+
+  \tparam SplineOrder The order of B-spline to use for the basis.
+
+  \param points The points to generate the point set with. Will be indexed as
+  (point,dim).
+
+  \param num_point The number of points to generate the point set with. This
+  is the size of the first dimension of points.
+
+  \param num_alloc The number of points to allocate. Must be less than or
+  equal to the input number of points.
+
+  \param block The grid block in which the points reside. All points must be
+  contained within the grid block.
+
+  \param An instance of the entity type to which the points will interpolate.
+
+  \param An instance of the spline function to use for interpolation.
+*/
+template <class PointCoordinates, class EntityType, int SplineOrder>
+PointSet<typename PointCoordinates::value_type, EntityType, SplineOrder,
+         typename PointCoordinates::device_type>
+createPointSet(
+    const PointCoordinates &points, const std::size_t num_point,
+    const std::size_t num_alloc,
+    const Block<UniformMesh<typename PointCoordinates::value_type>> &block,
+    EntityType, Spline<SplineOrder> )
+{
+    using scalar_type = typename PointCoordinates::value_type;
+
+    using device_type = typename PointCoordinates::device_type;
+
+    using set_type =
+        PointSet<scalar_type, EntityType, SplineOrder, device_type>;
+
+    set_type point_set;
+
+    static constexpr int ns = set_type::ns;
+
+    if ( num_point > num_alloc )
+        throw std::logic_error(
+            "Attempted to create point set with more points than allocation" );
+    point_set.num_point = num_point;
+    point_set.num_alloc = num_alloc;
+
+    point_set.logical_coords = Kokkos::View<scalar_type * [3], device_type>(
+        Kokkos::ViewAllocateWithoutInitializing( "PointSet::logical_coords" ),
+        num_alloc );
+
+    point_set.stencil = Kokkos::View<int * [ns][3], device_type>(
+        Kokkos::ViewAllocateWithoutInitializing( "PointSet::stencil" ),
+        num_alloc );
+
+    point_set.value = Kokkos::View<scalar_type * [ns][3], device_type>(
+        Kokkos::ViewAllocateWithoutInitializing( "PointSet::value" ),
+        num_alloc );
+
+    point_set.gradient =
+        Kokkos::View<scalar_type * [ns][ns][ns][3], device_type>(
+            Kokkos::ViewAllocateWithoutInitializing( "PointSet::gradients" ),
+            num_alloc );
+
+    auto local_mesh = createLocalMesh<Kokkos::HostSpace>( block );
+
+    point_set.dx = local_mesh.cellSize( 0, 0 );
+
+    point_set.rdx = 1.0 / point_set.dx;
+
+    for ( int d = 0; d < 3; ++d )
+        point_set.low_corner[d] = local_mesh.coordinate( EntityType(), 0, d );
+
+    updatePointSet( points, num_point, point_set );
+
+    return point_set;
+}
+
+//---------------------------------------------------------------------------//
+
+} // end namespace Cajita
+
+#endif // end CAJITA_POINTSET_HPP
+
+//---------------------------------------------------------------------------//

--- a/src/Cajita_Splines.hpp
+++ b/src/Cajita_Splines.hpp
@@ -3,8 +3,6 @@
 
 #include <Kokkos_Core.hpp>
 
-#include <cmath>
-
 namespace Cajita
 {
 //---------------------------------------------------------------------------//
@@ -26,7 +24,8 @@ struct Spline<1>
 
     /*!
       \brief Map a physical location to the logical space of the primal grid in
-      a single dimension. \param xp The coordinate to map to the logical space.
+      a single dimension.
+      \param xp The coordinate to map to the logical space.
       \param rdx The inverse of the physical distance between grid locations.
       \param low_x The physical location of the low corner of the primal
       grid.

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -65,8 +65,10 @@ set(MPI_TESTS
   GlobalGrid
   Block
   LocalMesh
+  PointSet
   Array
   Halo
+  Interpolation
   BovWriter
   )
 

--- a/unit_test/tstInterpolation.hpp
+++ b/unit_test/tstInterpolation.hpp
@@ -1,0 +1,240 @@
+/****************************************************************************
+ * Copyright (c) 2019 by the Cajita authors                                 *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Cajita library. Cajita is distributed under a   *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include <Kokkos_Core.hpp>
+
+#include <Cajita_Types.hpp>
+#include <Cajita_GlobalMesh.hpp>
+#include <Cajita_GlobalGrid.hpp>
+#include <Cajita_UniformDimPartitioner.hpp>
+#include <Cajita_Block.hpp>
+#include <Cajita_LocalMesh.hpp>
+#include <Cajita_Splines.hpp>
+#include <Cajita_PointSet.hpp>
+#include <Cajita_Interpolation.hpp>
+#include <Cajita_Array.hpp>
+
+#include <gtest/gtest.h>
+
+#include <mpi.h>
+
+#include <array>
+#include <vector>
+#include <cmath>
+
+using namespace Cajita;
+
+namespace Test
+{
+
+//---------------------------------------------------------------------------//
+void interpolationTest()
+{
+    // Create the global mesh.
+    std::array<double,3> low_corner = { -1.2, 0.1, 1.1 };
+    std::array<double,3> high_corner = { -0.3, 9.5, 2.3 };
+    double cell_size = 0.05;
+    auto global_mesh = createUniformGlobalMesh(
+        low_corner, high_corner, cell_size );
+
+    // Create the global grid.
+    UniformDimPartitioner partitioner;
+    std::array<bool,3> is_dim_periodic = {true,true,true};
+    auto global_grid = createGlobalGrid( MPI_COMM_WORLD,
+                                         global_mesh,
+                                         is_dim_periodic,
+                                         partitioner );
+
+    // Create a  grid block.
+    int halo_width = 1;
+    auto block = createBlock( global_grid, halo_width );
+    auto local_mesh = createLocalMesh<TEST_DEVICE>( *block );
+
+    // Create a point in the center of every cell.
+    auto cell_space =
+        block->indexSpace( Own(), Cell(), Local() );
+    int num_point = cell_space.size();
+    Kokkos::View<double*[3],TEST_DEVICE> points(
+        Kokkos::ViewAllocateWithoutInitializing("points"), num_point );
+    Kokkos::parallel_for(
+        "fill_points",
+        createExecutionPolicy(cell_space,TEST_EXECSPACE()),
+        KOKKOS_LAMBDA( const int i, const int j, const int k ){
+            int pi = i - halo_width;
+            int pj = j - halo_width;
+            int pk = k - halo_width;
+            int pid = pi + cell_space.extent(Dim::I) * (
+                pj + cell_space.extent(Dim::J) * pk );
+            points(pid,Dim::I) = local_mesh.coordinate(Cell(),i,Dim::I);
+            points(pid,Dim::J) = local_mesh.coordinate(Cell(),j,Dim::J);
+            points(pid,Dim::K) = local_mesh.coordinate(Cell(),k,Dim::K);
+        });
+
+    // Create a point set with cubic spline interpolation to the nodes.
+    auto point_set = createPointSet(
+        points, num_point, num_point, *block, Node(), Spline<3>() );
+
+    // Create a scalar field on the grid.
+    auto scalar_layout = createArrayLayout( block, 1, Node() );
+    auto scalar_grid_field =
+        createArray<double,TEST_DEVICE>( "scalar_grid_field", scalar_layout );
+    auto scalar_halo = createHalo( *scalar_grid_field, FullHaloPattern() );
+    auto scalar_grid_host = Kokkos::create_mirror_view( scalar_grid_field->view() );
+
+    // Create a vector field on the grid.
+    auto vector_layout = createArrayLayout( block, 3, Node() );
+    auto vector_grid_field =
+        createArray<double,TEST_DEVICE>( "vector_grid_field", vector_layout );
+    auto vector_halo = createHalo( *vector_grid_field, FullHaloPattern() );
+    auto vector_grid_host = Kokkos::create_mirror_view( vector_grid_field->view() );
+
+    // Create a scalar point field.
+    Kokkos::View<double*,TEST_DEVICE>
+        scalar_point_field( Kokkos::ViewAllocateWithoutInitializing(
+                                "scalar_point_field"), num_point );
+    auto scalar_point_host = Kokkos::create_mirror_view( scalar_point_field );
+
+    // Create a vector point field.
+    Kokkos::View<double*[3],TEST_DEVICE>
+        vector_point_field( Kokkos::ViewAllocateWithoutInitializing(
+                                "vector_point_field"), num_point );
+    auto vector_point_host = Kokkos::create_mirror_view( vector_point_field );
+
+    // Create a tensor point field.
+    Kokkos::View<double*[3][3],TEST_DEVICE>
+        tensor_point_field( Kokkos::ViewAllocateWithoutInitializing(
+                                "tensor_point_field"), num_point );
+    auto tensor_point_host = Kokkos::create_mirror_view( tensor_point_field );
+
+
+    // P2G
+    // ---
+
+    Kokkos::deep_copy( scalar_point_field, 3.5 );
+    Kokkos::deep_copy( vector_point_field, 3.5 );
+    Kokkos::deep_copy( tensor_point_field, 3.5 );
+
+    // Interpolate a scalar point value to the grid.
+    ArrayOp::assign( *scalar_grid_field, 0.0, Ghost() );
+    auto scalar_p2g = createScalarValueP2G( scalar_point_field, -0.5 );
+    p2g( scalar_p2g, point_set, *scalar_halo, *scalar_grid_field );
+    Kokkos::deep_copy( scalar_grid_host, scalar_grid_field->view() );
+    for ( int i = cell_space.min(Dim::I); i < cell_space.max(Dim::I); ++i )
+        for ( int j = cell_space.min(Dim::J); j < cell_space.max(Dim::J); ++j )
+            for ( int k = cell_space.min(Dim::K); k < cell_space.max(Dim::K); ++k )
+                EXPECT_FLOAT_EQ( scalar_grid_host(i,j,k,0), -1.75 );
+
+    // Interpolate a vector point value to the grid.
+    ArrayOp::assign( *vector_grid_field, 0.0, Ghost() );
+    auto vector_p2g = createVectorValueP2G( vector_point_field, -0.5 );
+    p2g( vector_p2g, point_set, *vector_halo, *vector_grid_field );
+    Kokkos::deep_copy( vector_grid_host, vector_grid_field->view() );
+    for ( int i = cell_space.min(Dim::I); i < cell_space.max(Dim::I); ++i )
+        for ( int j = cell_space.min(Dim::J); j < cell_space.max(Dim::J); ++j )
+            for ( int k = cell_space.min(Dim::K); k < cell_space.max(Dim::K); ++k )
+                for ( int d = 0; d < 3; ++d )
+                    EXPECT_FLOAT_EQ( vector_grid_host(i,j,k,d), -1.75 );
+
+    // Interpolate a scalar point gradient value to the grid.
+    ArrayOp::assign( *vector_grid_field, 0.0, Ghost() );
+    auto scalar_grad_p2g = createScalarGradientP2G( scalar_point_field, -0.5 );
+    p2g( scalar_grad_p2g, point_set, *vector_halo, *vector_grid_field );
+    Kokkos::deep_copy( vector_grid_host, vector_grid_field->view() );
+    for ( int i = cell_space.min(Dim::I); i < cell_space.max(Dim::I); ++i )
+        for ( int j = cell_space.min(Dim::J); j < cell_space.max(Dim::J); ++j )
+            for ( int k = cell_space.min(Dim::K); k < cell_space.max(Dim::K); ++k )
+                for ( int d = 0; d < 3; ++d )
+                    EXPECT_FLOAT_EQ( vector_grid_host(i,j,k,d) + 1.0, 1.0 );
+
+    // Interpolate a vector point divergence value to the grid.
+    ArrayOp::assign( *scalar_grid_field, 0.0, Ghost() );
+    auto vector_div_p2g = createVectorDivergenceP2G( vector_point_field, -0.5 );
+    p2g( vector_div_p2g, point_set, *scalar_halo, *scalar_grid_field );
+    Kokkos::deep_copy( scalar_grid_host, scalar_grid_field->view() );
+    for ( int i = cell_space.min(Dim::I); i < cell_space.max(Dim::I); ++i )
+        for ( int j = cell_space.min(Dim::J); j < cell_space.max(Dim::J); ++j )
+            for ( int k = cell_space.min(Dim::K); k < cell_space.max(Dim::K); ++k )
+                EXPECT_FLOAT_EQ( scalar_grid_host(i,j,k,0) + 1.0, 1.0 );
+
+    // Interpolate a tensor point divergence value to the grid.
+    ArrayOp::assign( *vector_grid_field, 0.0, Ghost() );
+    auto tensor_div_p2g = createTensorDivergenceP2G( tensor_point_field, -0.5 );
+    p2g( tensor_div_p2g, point_set, *vector_halo, *vector_grid_field );
+    Kokkos::deep_copy( vector_grid_host, vector_grid_field->view() );
+    for ( int i = cell_space.min(Dim::I); i < cell_space.max(Dim::I); ++i )
+        for ( int j = cell_space.min(Dim::J); j < cell_space.max(Dim::J); ++j )
+            for ( int k = cell_space.min(Dim::K); k < cell_space.max(Dim::K); ++k )
+                for ( int d = 0; d < 3; ++d )
+                    EXPECT_FLOAT_EQ( vector_grid_host(i,j,k,d) + 1.0, 1.0 );
+
+
+    // G2P
+    // ---
+
+    ArrayOp::assign( *scalar_grid_field, 3.5, Own() );
+    ArrayOp::assign( *vector_grid_field, 3.5, Own() );
+
+    // Interpolate a scalar grid value to the points.
+    Kokkos::deep_copy( scalar_point_field, 0.0 );
+    auto scalar_value_g2p = createScalarValueG2P( scalar_point_field, -0.5 );
+    g2p( *scalar_grid_field, *scalar_halo, point_set, scalar_value_g2p );
+    Kokkos::deep_copy( scalar_point_host, scalar_point_field );
+    for ( int p = 0; p < num_point; ++p )
+        EXPECT_FLOAT_EQ( scalar_point_host(p), -1.75 );
+
+    // Interpolate a vector grid value to the points.
+    Kokkos::deep_copy( vector_point_field, 0.0 );
+    auto vector_value_g2p = createVectorValueG2P( vector_point_field, -0.5 );
+    g2p( *vector_grid_field, *vector_halo, point_set, vector_value_g2p );
+    Kokkos::deep_copy( vector_point_host, vector_point_field );
+    for ( int p = 0; p < num_point; ++p )
+        for ( int d = 0; d < 3; ++d )
+            EXPECT_FLOAT_EQ( vector_point_host(p,d), -1.75 );
+
+    // Interpolate a scalar grid gradient to the points.
+    Kokkos::deep_copy( vector_point_field, 0.0 );
+    auto scalar_gradient_g2p = createScalarGradientG2P( vector_point_field, -0.5 );
+    g2p( *scalar_grid_field, *scalar_halo, point_set, scalar_gradient_g2p );
+    Kokkos::deep_copy( vector_point_host, vector_point_field );
+    for ( int p = 0; p < num_point; ++p )
+        for ( int d = 0; d < 3; ++d )
+            EXPECT_FLOAT_EQ( vector_point_host(p,d) + 1.0, 1.0 );
+
+    // Interpolate a vector grid gradient to the points.
+    Kokkos::deep_copy( tensor_point_field, 0.0 );
+    auto vector_gradient_g2p = createVectorGradientG2P( tensor_point_field, -0.5 );
+    g2p( *vector_grid_field, *vector_halo, point_set, vector_gradient_g2p );
+    Kokkos::deep_copy( tensor_point_host, tensor_point_field );
+    for ( int p = 0; p < num_point; ++p )
+        for ( int i = 0; i < 3; ++i )
+            for ( int j = 0; j < 3; ++j )
+                EXPECT_FLOAT_EQ( tensor_point_host(p,i,j) + 1.0, 1.0 );
+
+    // Interpolate a vector grid divergence to the points.
+    Kokkos::deep_copy( scalar_point_field, 0.0 );
+    auto vector_div_g2p = createVectorDivergenceG2P( scalar_point_field, -0.5 );
+    g2p( *vector_grid_field, *vector_halo, point_set, vector_div_g2p );
+    Kokkos::deep_copy( scalar_point_host, scalar_point_field );
+    for ( int p = 0; p < num_point; ++p )
+        EXPECT_FLOAT_EQ( scalar_point_host(p) + 1.0, 1.0 );
+}
+
+//---------------------------------------------------------------------------//
+// RUN TESTS
+//---------------------------------------------------------------------------//
+TEST( interpolation, interpolation_test )
+{
+    interpolationTest();
+}
+
+//---------------------------------------------------------------------------//
+
+} // end namespace Test

--- a/unit_test/tstPointSet.hpp
+++ b/unit_test/tstPointSet.hpp
@@ -1,0 +1,205 @@
+/****************************************************************************
+ * Copyright (c) 2019 by the Cajita authors                                 *
+ * All rights reserved.                                                     *
+ *                                                                          *
+ * This file is part of the Cajita library. Cajita is distributed under a   *
+ * BSD 3-clause license. For the licensing terms see the LICENSE file in    *
+ * the top-level directory.                                                 *
+ *                                                                          *
+ * SPDX-License-Identifier: BSD-3-Clause                                    *
+ ****************************************************************************/
+
+#include <Kokkos_Core.hpp>
+
+#include <Cajita_Types.hpp>
+#include <Cajita_GlobalMesh.hpp>
+#include <Cajita_GlobalGrid.hpp>
+#include <Cajita_UniformDimPartitioner.hpp>
+#include <Cajita_Block.hpp>
+#include <Cajita_LocalMesh.hpp>
+#include <Cajita_Splines.hpp>
+#include <Cajita_PointSet.hpp>
+
+#include <gtest/gtest.h>
+
+#include <mpi.h>
+
+#include <array>
+#include <vector>
+#include <cmath>
+
+using namespace Cajita;
+
+namespace Test
+{
+
+//---------------------------------------------------------------------------//
+void pointSetTest()
+{
+    // Create the global mesh.
+    std::array<double,3> low_corner = { -1.2, 0.1, 1.1 };
+    std::array<double,3> high_corner = { -0.3, 9.5, 2.3 };
+    double cell_size = 0.05;
+    auto global_mesh = createUniformGlobalMesh(
+        low_corner, high_corner, cell_size );
+
+    // Create the global grid.
+    UniformDimPartitioner partitioner;
+    std::array<bool,3> is_dim_periodic = {true,true,true};
+    auto global_grid = createGlobalGrid( MPI_COMM_WORLD,
+                                         global_mesh,
+                                         is_dim_periodic,
+                                         partitioner );
+
+    // Create a  grid block.
+    int halo_width = 1;
+    auto block = createBlock( global_grid, halo_width );
+    auto local_mesh = createLocalMesh<TEST_DEVICE>( *block );
+
+    // Create a point in the center of every cell.
+    auto cell_space =
+        block->indexSpace( Own(), Cell(), Local() );
+    int num_point = cell_space.size();
+    Kokkos::View<double*[3],TEST_DEVICE> points(
+        Kokkos::ViewAllocateWithoutInitializing("points"), num_point );
+    Kokkos::parallel_for(
+        "fill_points",
+        createExecutionPolicy(cell_space,TEST_EXECSPACE()),
+        KOKKOS_LAMBDA( const int i, const int j, const int k ){
+            int pi = i - halo_width;
+            int pj = j - halo_width;
+            int pk = k - halo_width;
+            int pid = pi + cell_space.extent(Dim::I) * (
+                pj + cell_space.extent(Dim::J) * pk );
+            points(pid,Dim::I) = local_mesh.coordinate(Cell(),i,Dim::I);
+            points(pid,Dim::J) = local_mesh.coordinate(Cell(),j,Dim::J);
+            points(pid,Dim::K) = local_mesh.coordinate(Cell(),k,Dim::K);
+        });
+
+    // Create a point set with linear spline interpolation to the nodes.
+    auto point_set = createPointSet(
+        points, num_point, num_point, *block, Node(), Spline<1>() );
+
+    // Check the point set data.
+    EXPECT_EQ( point_set.num_point, num_point );
+    EXPECT_EQ( point_set.dx, cell_size );
+    EXPECT_EQ( point_set.rdx, 1.0 / cell_size );
+    for ( int d = 0; d < 3; ++d )
+        EXPECT_EQ( point_set.low_corner[d],
+                   local_mesh.coordinate(Node(),0,d) );
+
+    // Check logical coordinates
+    auto logical_coords_host = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), point_set.logical_coords );
+    for ( int i = cell_space.min(Dim::I); i < cell_space.max(Dim::I); ++i )
+        for ( int j = cell_space.min(Dim::J); j < cell_space.max(Dim::J); ++j )
+            for ( int k = cell_space.min(Dim::K); k < cell_space.max(Dim::K); ++k )
+            {
+                int pi = i - halo_width;
+                int pj = j - halo_width;
+                int pk = k - halo_width;
+                int pid = pi + cell_space.extent(Dim::I) * (
+                    pj + cell_space.extent(Dim::J) * pk );
+                EXPECT_FLOAT_EQ( logical_coords_host(pid,Dim::I), i + 0.5 );
+                EXPECT_FLOAT_EQ( logical_coords_host(pid,Dim::J), j + 0.5 );
+                EXPECT_FLOAT_EQ( logical_coords_host(pid,Dim::K), k + 0.5 );
+            }
+
+    // Check stencil.
+    auto stencil_host = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), point_set.stencil );
+    for ( int i = cell_space.min(Dim::I); i < cell_space.max(Dim::I); ++i )
+        for ( int j = cell_space.min(Dim::J); j < cell_space.max(Dim::J); ++j )
+            for ( int k = cell_space.min(Dim::K); k < cell_space.max(Dim::K); ++k )
+            {
+                int pi = i - halo_width;
+                int pj = j - halo_width;
+                int pk = k - halo_width;
+                int pid = pi + cell_space.extent(Dim::I) * (
+                    pj + cell_space.extent(Dim::J) * pk );
+                EXPECT_EQ( stencil_host(pid,0,Dim::I), i );
+                EXPECT_EQ( stencil_host(pid,1,Dim::I), i + 1 );
+                EXPECT_EQ( stencil_host(pid,0,Dim::J), j );
+                EXPECT_EQ( stencil_host(pid,1,Dim::J), j + 1 );
+                EXPECT_EQ( stencil_host(pid,0,Dim::K), k );
+                EXPECT_EQ( stencil_host(pid,1,Dim::K), k + 1 );
+            }
+
+    // Check values.
+    auto values_host = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), point_set.value );
+    for ( int i = cell_space.min(Dim::I); i < cell_space.max(Dim::I); ++i )
+        for ( int j = cell_space.min(Dim::J); j < cell_space.max(Dim::J); ++j )
+            for ( int k = cell_space.min(Dim::K); k < cell_space.max(Dim::K); ++k )
+            {
+                int pi = i - halo_width;
+                int pj = j - halo_width;
+                int pk = k - halo_width;
+                int pid = pi + cell_space.extent(Dim::I) * (
+                    pj + cell_space.extent(Dim::J) * pk );
+                EXPECT_FLOAT_EQ( values_host(pid,0,Dim::I), 0.5 );
+                EXPECT_FLOAT_EQ( values_host(pid,1,Dim::I), 0.5 );
+                EXPECT_FLOAT_EQ( values_host(pid,0,Dim::J), 0.5 );
+                EXPECT_FLOAT_EQ( values_host(pid,1,Dim::J), 0.5 );
+                EXPECT_FLOAT_EQ( values_host(pid,0,Dim::K), 0.5 );
+                EXPECT_FLOAT_EQ( values_host(pid,1,Dim::K), 0.5 );
+            }
+
+    // Check gradients.
+    auto gradients_host = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), point_set.gradient );
+    for ( int i = cell_space.min(Dim::I); i < cell_space.max(Dim::I); ++i )
+        for ( int j = cell_space.min(Dim::J); j < cell_space.max(Dim::J); ++j )
+            for ( int k = cell_space.min(Dim::K); k < cell_space.max(Dim::K); ++k )
+            {
+                int pi = i - halo_width;
+                int pj = j - halo_width;
+                int pk = k - halo_width;
+                int pid = pi + cell_space.extent(Dim::I) * (
+                    pj + cell_space.extent(Dim::J) * pk );
+
+                EXPECT_FLOAT_EQ( gradients_host(pid,0,0,0,Dim::I), -0.25/cell_size );
+                EXPECT_FLOAT_EQ( gradients_host(pid,0,0,0,Dim::J), -0.25/cell_size );
+                EXPECT_FLOAT_EQ( gradients_host(pid,0,0,0,Dim::K), -0.25/cell_size );
+
+                EXPECT_FLOAT_EQ( gradients_host(pid,1,0,0,Dim::I), 0.25/cell_size );
+                EXPECT_FLOAT_EQ( gradients_host(pid,1,0,0,Dim::J), -0.25/cell_size );
+                EXPECT_FLOAT_EQ( gradients_host(pid,1,0,0,Dim::K), -0.25/cell_size );
+
+                EXPECT_FLOAT_EQ( gradients_host(pid,1,1,0,Dim::I), 0.25/cell_size );
+                EXPECT_FLOAT_EQ( gradients_host(pid,1,1,0,Dim::J), 0.25/cell_size );
+                EXPECT_FLOAT_EQ( gradients_host(pid,1,1,0,Dim::K), -0.25/cell_size );
+
+                EXPECT_FLOAT_EQ( gradients_host(pid,0,1,0,Dim::I), -0.25/cell_size );
+                EXPECT_FLOAT_EQ( gradients_host(pid,0,1,0,Dim::J), 0.25/cell_size );
+                EXPECT_FLOAT_EQ( gradients_host(pid,0,1,0,Dim::K), -0.25/cell_size );
+
+                EXPECT_FLOAT_EQ( gradients_host(pid,0,0,1,Dim::I), -0.25/cell_size );
+                EXPECT_FLOAT_EQ( gradients_host(pid,0,0,1,Dim::J), -0.25/cell_size );
+                EXPECT_FLOAT_EQ( gradients_host(pid,0,0,1,Dim::K), 0.25/cell_size );
+
+                EXPECT_FLOAT_EQ( gradients_host(pid,1,0,1,Dim::I), 0.25/cell_size );
+                EXPECT_FLOAT_EQ( gradients_host(pid,1,0,1,Dim::J), -0.25/cell_size );
+                EXPECT_FLOAT_EQ( gradients_host(pid,1,0,1,Dim::K), 0.25/cell_size );
+
+                EXPECT_FLOAT_EQ( gradients_host(pid,1,1,1,Dim::I), 0.25/cell_size );
+                EXPECT_FLOAT_EQ( gradients_host(pid,1,1,1,Dim::J), 0.25/cell_size );
+                EXPECT_FLOAT_EQ( gradients_host(pid,1,1,1,Dim::K), 0.25/cell_size );
+
+                EXPECT_FLOAT_EQ( gradients_host(pid,0,1,1,Dim::I), -0.25/cell_size );
+                EXPECT_FLOAT_EQ( gradients_host(pid,0,1,1,Dim::J), 0.25/cell_size );
+                EXPECT_FLOAT_EQ( gradients_host(pid,0,1,1,Dim::K), 0.25/cell_size );
+            }
+}
+
+//---------------------------------------------------------------------------//
+// RUN TESTS
+//---------------------------------------------------------------------------//
+TEST( point_set, update_test )
+{
+    pointSetTest();
+}
+
+//---------------------------------------------------------------------------//
+
+} // end namespace Test


### PR DESCRIPTION
This PR adds point/grid interpolation to Cajita based on the spline discretization added in #14. New functionalities include

* `Cajita::PointSet` - Defines a set of point coordinates over which the interpolation will be performed. These points must live inside of a given grid. The `PointSet` will compute the deposition stencil of the point with respect to whatever entity type is being interpolated to as well as the type of spline to use. This point set can be updated repeatedly with new coordinates without allocation as long as the number of points does not exceed the allocated amount. A `Kokkos::View`, `Cabana::Slice`, or other object that implements an appropriate `operator()` can be used to assign coordinates.

* `Cajita::p2g()` - defines point-to-grid interpolation. Given a `PointSet`, grid array, and functor for interpolation this performs the interpolation including MPI communication via `scatter`.

* `Cajita::g2p()` = defines grid-to-point interpolation. Given a `PointSet`, grid array, and functor this also performs the interpolation including MPI communication via `gather`. 

Access the the data associated with points (e.g. a `Kokkos::View` or `Cabana::Slice`) is provided through functors with signatures specific to `p2g` or `g2p`. Some default implementations are provided for basic interpolations such as simple scalar interpolation or gradient interpolation but a user can also easily write their own. For example, a user could evaluate a more complex function using multiple point values to assemble contributions to a grid field.

In general, view `p2g()` and `g2p()` as interfaces to these general operations. I have plans for an optimization campaign in the future for these implementations.