### PR TITLE
Remove MPI Comm Tags

### DIFF
--- a/src/Cajita_GlobalGrid.cpp
+++ b/src/Cajita_GlobalGrid.cpp
@@ -79,6 +79,14 @@ GlobalGrid<MeshType>::GlobalGrid(
 }
 
 //---------------------------------------------------------------------------//
+// Destructor.
+template <class MeshType>
+GlobalGrid<MeshType>::~GlobalGrid()
+{
+    MPI_Comm_free( &_cart_comm );
+}
+
+//---------------------------------------------------------------------------//
 // Get the grid communicator.
 template <class MeshType>
 MPI_Comm GlobalGrid<MeshType>::comm() const

--- a/src/Cajita_GlobalGrid.hpp
+++ b/src/Cajita_GlobalGrid.hpp
@@ -45,6 +45,9 @@ class GlobalGrid
                 const std::array<bool, 3> &periodic,
                 const Partitioner &partitioner );
 
+    // Destructor.
+    ~GlobalGrid();
+
     // Get the communicator. This communicator was generated with a Cartesian
     // topology.
     MPI_Comm comm() const;

--- a/src/Cajita_Halo.hpp
+++ b/src/Cajita_Halo.hpp
@@ -175,6 +175,9 @@ class Halo
         }
     }
 
+    // Destructor.
+    ~Halo() { MPI_Comm_free( &_comm ); }
+
     /*!
       \brief Gather data into our ghosts from their owners.
       \param array The array to gather.

--- a/src/Cajita_Interpolation.hpp
+++ b/src/Cajita_Interpolation.hpp
@@ -108,7 +108,7 @@ void p2g(
 
     // Scatter interpolation contributions in the halo back to their owning
     // ranks.
-    halo.scatter( array, 4321 );
+    halo.scatter( array );
 }
 
 //---------------------------------------------------------------------------//
@@ -414,7 +414,7 @@ void g2p(
     using execution_space = typename DeviceType::execution_space;
 
     // Gather data into the halo before interpolating.
-    halo.gather( array, 4321 );
+    halo.gather( array );
 
     // Get a view of the array data.
     auto array_view = array.view();

--- a/unit_test/tstBovWriter.hpp
+++ b/unit_test/tstBovWriter.hpp
@@ -93,7 +93,7 @@ void writeTest()
 
     // Gather the node data.
     auto node_halo = createHalo( *node_field, FullHaloPattern() );
-    node_halo->gather( *node_field, 453 );
+    node_halo->gather( *node_field );
 
     // Write the fields to a file.
     BovWriter::writeTimeStep( 302, 3.43, *cell_field );

--- a/unit_test/tstHalo.hpp
+++ b/unit_test/tstHalo.hpp
@@ -69,7 +69,7 @@ void gatherScatterTest( const ManualPartitioner& partitioner,
         auto halo = createHalo( *array, FullHaloPattern(), halo_width );
 
         // Gather into the ghosts.
-        halo->gather( *array, 124 );
+        halo->gather( *array );
 
         // Check the gather. We should get 1 everywhere in the array now where
         // there was ghost overlap. Otherwise there will still be 0.
@@ -92,7 +92,7 @@ void gatherScatterTest( const ManualPartitioner& partitioner,
                             EXPECT_EQ( host_view(i,j,k,l), 1.0 );
 
         // Scatter from the ghosts back to owned.
-        halo->scatter( *array, 125 );
+        halo->scatter( *array );
 
         // Check the scatter. The value of the cell should be a function of how
         // many neighbors it has. Corner neighbors get 8, edge neighbors get 4,


### PR DESCRIPTION
Uses `MPI_Comm_dup` in the `Halo` to avoid the need for users to input an MPI tag for the point-to-point communication as the duplicated communicator will operate in a separate communication space.

Note that this change breaks backwards compatibility.

Fixes #12 