### PR TITLE
Rename Block -> LocalGrid

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(HEADERS_PUBLIC
   Cajita.hpp
   Cajita_Array.hpp
-  Cajita_Block.hpp
+  Cajita_LocalGrid.hpp
   Cajita_BovWriter.hpp
   Cajita_GlobalGrid.hpp
   Cajita_GlobalMesh.hpp
@@ -19,7 +19,7 @@ set(HEADERS_PUBLIC
   )
 
 set(SOURCES_PUBLIC
-  Cajita_Block.cpp
+  Cajita_LocalGrid.cpp
   Cajita_GlobalGrid.cpp
   Cajita_GlobalMesh.cpp
   Cajita_IndexSpace.cpp

--- a/src/Cajita.hpp
+++ b/src/Cajita.hpp
@@ -13,7 +13,6 @@
 #define CAJITA_HPP
 
 #include <Cajita_Array.hpp>
-#include <Cajita_Block.hpp>
 #include <Cajita_BovWriter.hpp>
 #include <Cajita_Config.hpp>
 #include <Cajita_GlobalGrid.hpp>
@@ -21,6 +20,7 @@
 #include <Cajita_Halo.hpp>
 #include <Cajita_IndexSpace.hpp>
 #include <Cajita_Interpolation.hpp>
+#include <Cajita_LocalGrid.hpp>
 #include <Cajita_LocalMesh.hpp>
 #include <Cajita_ManualPartitioner.hpp>
 #include <Cajita_MpiTraits.hpp>

--- a/src/Cajita_BovWriter.hpp
+++ b/src/Cajita_BovWriter.hpp
@@ -88,7 +88,7 @@ MPI_Datatype createSubarray( const Array_t &array,
                              const std::array<long, 4> &global_extents )
 {
     using value_type = typename Array_t::value_type;
-    const auto &global_grid = array.layout()->block()->globalGrid();
+    const auto &global_grid = array.layout()->localGrid()->globalGrid();
 
     int local_start[4] = {
         static_cast<int>( global_grid.globalOffset( Dim::K ) ),
@@ -136,7 +136,7 @@ void writeTimeStep( const int time_step_index, const double time,
     using execution_space = typename device_type::execution_space;
 
     // Get the global grid.
-    const auto &global_grid = array.layout()->block()->globalGrid();
+    const auto &global_grid = array.layout()->localGrid()->globalGrid();
 
     // Get the global mesh.
     const auto &global_mesh = global_grid.globalMesh();

--- a/src/Cajita_Halo.hpp
+++ b/src/Cajita_Halo.hpp
@@ -100,7 +100,7 @@ class Halo
           const int width = -1 )
     {
         // Duplicate the communicator so we have our own communication space.
-        MPI_Comm_dup( layout.block()->globalGrid().comm(), &_comm );
+        MPI_Comm_dup( layout.localGrid()->globalGrid().comm(), &_comm );
 
         // Function to get the local id of the neighbor.
         auto neighbor_id = []( const int i, const int j, const int k ) {
@@ -133,7 +133,7 @@ class Halo
             auto k = n[Dim::K];
 
             // Get the rank of the neighbor.
-            int rank = layout.block()->neighborRank( i, j, k );
+            int rank = layout.localGrid()->neighborRank( i, j, k );
 
             // If this is a valid rank add it as a neighbor.
             if ( rank >= 0 )

--- a/src/Cajita_LocalGrid.hpp
+++ b/src/Cajita_LocalGrid.hpp
@@ -9,8 +9,8 @@
  * SPDX-License-Identifier: BSD-3-Clause                                    *
  ****************************************************************************/
 
-#ifndef CAJITA_BLOCK_HPP
-#define CAJITA_BLOCK_HPP
+#ifndef CAJITA_LOCALGRID_HPP
+#define CAJITA_LOCALGRID_HPP
 
 #include <Cajita_GlobalGrid.hpp>
 #include <Cajita_IndexSpace.hpp>
@@ -22,10 +22,10 @@
 namespace Cajita
 {
 //---------------------------------------------------------------------------//
-// Local logical grid block.
+// Local logical grid.
 //---------------------------------------------------------------------------//
 template <class MeshType>
-class Block
+class LocalGrid
 {
   public:
     // Mesh type.
@@ -33,29 +33,29 @@ class Block
 
     /*!
       \brief Constructor.
-      \param global_grid The global grid from which the block will be
+      \param global_grid The global grid from which the local grid will be
       constructed.
       \param halo_cell_width The number of halo cells surrounding the locally
       owned cells.
     */
-    Block( const std::shared_ptr<GlobalGrid<MeshType>> &global_grid,
-           const int halo_cell_width );
+    LocalGrid( const std::shared_ptr<GlobalGrid<MeshType>> &global_grid,
+               const int halo_cell_width );
 
-    // Get the global grid that owns the block.
+    // Get the global grid that owns the local grid.
     const GlobalGrid<MeshType> &globalGrid() const;
 
     // Get the number of cells in the halo.
     int haloCellWidth() const;
 
-    // Given the relative offsets of a neighbor rank relative to this block's
-    // indices get the of the neighbor. If the neighbor rank is out of bounds
-    // return -1. Note that in the case of periodic boundaries out of bounds
-    // indices are allowed as the indices will be wrapped around the periodic
-    // boundary.
+    // Given the relative offsets of a neighbor rank relative to this local
+    // grid's indices get the of the neighbor. If the neighbor rank is out of
+    // bounds return -1. Note that in the case of periodic boundaries out of
+    // bounds indices are allowed as the indices will be wrapped around the
+    // periodic boundary.
     int neighborRank( const int off_i, const int off_j, const int off_k ) const;
 
     /*
-       Get the index space of the block.
+       Get the index space of the local grid.
 
        Interface has the same structure as:
 
@@ -109,7 +109,8 @@ class Block
        entity indices shared with that neighbor in the given
        decomposition. Optionally provide a halo width for the shared
        space. This halo width must be less than or equal to the halo width of
-       the block. The default behavior is to use the halo width of the block.
+       the local grid. The default behavior is to use the halo width of the
+       local grid.
 
        Interface same structure as:
 
@@ -185,13 +186,13 @@ class Block
                                     const int halo_width = -1 ) const;
 
   private:
-    // Get the global index space of the block.
+    // Get the global index space of the local grid.
     template <class EntityType>
     IndexSpace<3> globalIndexSpace( Own, EntityType ) const;
     template <class EntityType>
     IndexSpace<3> globalIndexSpace( Ghost, EntityType ) const;
 
-    // Get the face index space of the block.
+    // Get the face index space of the local grid.
     template <int Dir>
     IndexSpace<3> faceIndexSpace( Own, Face<Dir>, Local ) const;
     template <int Dir>
@@ -212,7 +213,7 @@ class Block
                                         const int off_j, const int off_k,
                                         const int halo_width ) const;
 
-    // Get the edge index space of the block.
+    // Get the edge index space of the local grid.
     template <int Dir>
     IndexSpace<3> edgeIndexSpace( Own, Edge<Dir>, Local ) const;
     template <int Dir>
@@ -242,22 +243,23 @@ class Block
 // Creation function.
 //---------------------------------------------------------------------------//
 /*!
-  \brief Create a block.
-  \param global_grid The global grid from which the block will be
+  \brief Create a local grid.
+  \param global_grid The global grid from which the local grid will be
   constructed.
   \param halo_cell_width The number of halo cells surrounding the locally
   owned cells.
 */
 template <class MeshType>
-std::shared_ptr<Block<MeshType>>
-createBlock( const std::shared_ptr<GlobalGrid<MeshType>> &global_grid,
-             const int halo_cell_width )
+std::shared_ptr<LocalGrid<MeshType>>
+createLocalGrid( const std::shared_ptr<GlobalGrid<MeshType>> &global_grid,
+                 const int halo_cell_width )
 {
-    return std::make_shared<Block<MeshType>>( global_grid, halo_cell_width );
+    return std::make_shared<LocalGrid<MeshType>>( global_grid,
+                                                  halo_cell_width );
 }
 
 //---------------------------------------------------------------------------//
 
 } // end namespace Cajita
 
-#endif // end CAJITA_BLOCK_HPP
+#endif // end CAJITA_LOCALGRID_HPP

--- a/src/Cajita_PointSet.hpp
+++ b/src/Cajita_PointSet.hpp
@@ -12,7 +12,7 @@
 #ifndef CAJITA_POINTSET_HPP
 #define CAJITA_POINTSET_HPP
 
-#include <Cajita_Block.hpp>
+#include <Cajita_LocalGrid.hpp>
 #include <Cajita_LocalMesh.hpp>
 #include <Cajita_Splines.hpp>
 
@@ -111,7 +111,7 @@ struct PointSet
   \tparam PointSetType The type of point set to update.
 
   \param points The points over which to build the point set. Will be indexed
-  as (point,dim). All points must be contained within the grid block that was
+  as (point,dim). All points must be contained within the local grid that was
   used to generate the point set.
 
   \param num_point The number of points. This is the size of the first
@@ -226,8 +226,8 @@ void updatePointSet( const PointCoordinates &points,
   \param num_alloc The number of points to allocate. Must be less than or
   equal to the input number of points.
 
-  \param block The grid block in which the points reside. All points must be
-  contained within the grid block.
+  \param local_grid The local grid in which the points reside. All points must
+  be contained within the local grid.
 
   \param An instance of the entity type to which the points will interpolate.
 
@@ -239,7 +239,8 @@ PointSet<typename PointCoordinates::value_type, EntityType, SplineOrder,
 createPointSet(
     const PointCoordinates &points, const std::size_t num_point,
     const std::size_t num_alloc,
-    const Block<UniformMesh<typename PointCoordinates::value_type>> &block,
+    const LocalGrid<UniformMesh<typename PointCoordinates::value_type>>
+        &local_grid,
     EntityType, Spline<SplineOrder> )
 {
     using scalar_type = typename PointCoordinates::value_type;
@@ -276,7 +277,7 @@ createPointSet(
             Kokkos::ViewAllocateWithoutInitializing( "PointSet::gradients" ),
             num_alloc );
 
-    auto local_mesh = createLocalMesh<Kokkos::HostSpace>( block );
+    auto local_mesh = createLocalMesh<Kokkos::HostSpace>( local_grid );
 
     int idx_low[3] = {0, 0, 0};
     point_set.dx = local_mesh.measure( Edge<Dim::I>(), idx_low );

--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -63,7 +63,7 @@ set(SERIAL_TESTS
 
 set(MPI_TESTS
   GlobalGrid
-  Block
+  LocalGrid
   LocalMesh
   PointSet
   Array

--- a/unit_test/tstArray.hpp
+++ b/unit_test/tstArray.hpp
@@ -64,14 +64,14 @@ void layoutTest()
     // Check the owned index_space.
     auto array_node_owned_space =
         node_layout->indexSpace( Own(), Local() );
-    auto block_node_owned_space =
-        node_layout->block()->indexSpace( Own(), Node(), Local() );
+    auto grid_node_owned_space =
+        node_layout->localGrid()->indexSpace( Own(), Node(), Local() );
     for ( int d = 0; d < 3; ++d )
     {
         EXPECT_EQ( array_node_owned_space.min(d),
-                   block_node_owned_space.min(d) );
+                   grid_node_owned_space.min(d) );
         EXPECT_EQ( array_node_owned_space.max(d),
-                   block_node_owned_space.max(d) );
+                   grid_node_owned_space.max(d) );
     }
     EXPECT_EQ( array_node_owned_space.min(3), 0 );
     EXPECT_EQ( array_node_owned_space.max(3), dofs_per_node );
@@ -79,14 +79,14 @@ void layoutTest()
     // Check the ghosted index_space.
     auto array_node_ghosted_space =
         node_layout->indexSpace( Ghost(), Local() );
-    auto block_node_ghosted_space =
-        node_layout->block()->indexSpace( Ghost(), Node(), Local() );
+    auto grid_node_ghosted_space =
+        node_layout->localGrid()->indexSpace( Ghost(), Node(), Local() );
     for ( int d = 0; d < 3; ++d )
     {
         EXPECT_EQ( array_node_ghosted_space.min(d),
-                   block_node_ghosted_space.min(d) );
+                   grid_node_ghosted_space.min(d) );
         EXPECT_EQ( array_node_ghosted_space.max(d),
-                   block_node_ghosted_space.max(d) );
+                   grid_node_ghosted_space.max(d) );
     }
     EXPECT_EQ( array_node_ghosted_space.min(3), 0 );
     EXPECT_EQ( array_node_ghosted_space.max(3), dofs_per_node );
@@ -94,14 +94,14 @@ void layoutTest()
     // Check the shared owned index_space.
     auto array_node_shared_owned_space =
         node_layout->sharedIndexSpace(Own(),-1,0,1);
-    auto block_node_shared_owned_space =
-        node_layout->block()->sharedIndexSpace( Own(), Node(), -1, 0, 1 );
+    auto grid_node_shared_owned_space =
+        node_layout->localGrid()->sharedIndexSpace( Own(), Node(), -1, 0, 1 );
     for ( int d = 0; d < 3; ++d )
     {
         EXPECT_EQ( array_node_shared_owned_space.min(d),
-                   block_node_shared_owned_space.min(d) );
+                   grid_node_shared_owned_space.min(d) );
         EXPECT_EQ( array_node_shared_owned_space.max(d),
-                   block_node_shared_owned_space.max(d) );
+                   grid_node_shared_owned_space.max(d) );
     }
     EXPECT_EQ( array_node_shared_owned_space.min(3), 0 );
     EXPECT_EQ( array_node_shared_owned_space.max(3), dofs_per_node );
@@ -109,14 +109,14 @@ void layoutTest()
     // Check the shared ghosted index_space.
     auto array_node_shared_ghosted_space =
         node_layout->sharedIndexSpace(Ghost(),1,-1,0);
-    auto block_node_shared_ghosted_space =
-        node_layout->block()->sharedIndexSpace( Ghost(), Node(), 1, -1, 0 );
+    auto grid_node_shared_ghosted_space =
+        node_layout->localGrid()->sharedIndexSpace( Ghost(), Node(), 1, -1, 0 );
     for ( int d = 0; d < 3; ++d )
     {
         EXPECT_EQ( array_node_shared_ghosted_space.min(d),
-                   block_node_shared_ghosted_space.min(d) );
+                   grid_node_shared_ghosted_space.min(d) );
         EXPECT_EQ( array_node_shared_ghosted_space.max(d),
-                   block_node_shared_ghosted_space.max(d) );
+                   grid_node_shared_ghosted_space.max(d) );
     }
     EXPECT_EQ( array_node_shared_ghosted_space.min(3), 0 );
     EXPECT_EQ( array_node_shared_ghosted_space.max(3), dofs_per_node );
@@ -129,14 +129,14 @@ void layoutTest()
     // Check the owned index_space.
     auto array_cell_owned_space =
         cell_layout->indexSpace( Own(), Local() );
-    auto block_cell_owned_space =
-        cell_layout->block()->indexSpace( Own(), Cell(), Local() );
+    auto grid_cell_owned_space =
+        cell_layout->localGrid()->indexSpace( Own(), Cell(), Local() );
     for ( int d = 0; d < 3; ++d )
     {
         EXPECT_EQ( array_cell_owned_space.min(d),
-                   block_cell_owned_space.min(d) );
+                   grid_cell_owned_space.min(d) );
         EXPECT_EQ( array_cell_owned_space.max(d),
-                   block_cell_owned_space.max(d) );
+                   grid_cell_owned_space.max(d) );
     }
     EXPECT_EQ( array_cell_owned_space.min(3), 0 );
     EXPECT_EQ( array_cell_owned_space.max(3), dofs_per_cell );
@@ -144,14 +144,14 @@ void layoutTest()
     // Check the ghosted index_space.
     auto array_cell_ghosted_space =
         cell_layout->indexSpace( Ghost(), Local() );
-    auto block_cell_ghosted_space =
-        cell_layout->block()->indexSpace( Ghost(), Cell(), Local() );
+    auto grid_cell_ghosted_space =
+        cell_layout->localGrid()->indexSpace( Ghost(), Cell(), Local() );
     for ( int d = 0; d < 3; ++d )
     {
         EXPECT_EQ( array_cell_ghosted_space.min(d),
-                   block_cell_ghosted_space.min(d) );
+                   grid_cell_ghosted_space.min(d) );
         EXPECT_EQ( array_cell_ghosted_space.max(d),
-                   block_cell_ghosted_space.max(d) );
+                   grid_cell_ghosted_space.max(d) );
     }
     EXPECT_EQ( array_cell_ghosted_space.min(3), 0 );
     EXPECT_EQ( array_cell_ghosted_space.max(3), dofs_per_cell );
@@ -159,14 +159,14 @@ void layoutTest()
     // Check the shared owned index_space.
     auto array_cell_shared_owned_space =
         cell_layout->sharedIndexSpace(Own(),0,1,-1);
-    auto block_cell_shared_owned_space =
-        cell_layout->block()->sharedIndexSpace( Own(), Cell(), 0, 1, -1 );
+    auto grid_cell_shared_owned_space =
+        cell_layout->localGrid()->sharedIndexSpace( Own(), Cell(), 0, 1, -1 );
     for ( int d = 0; d < 3; ++d )
     {
         EXPECT_EQ( array_cell_shared_owned_space.min(d),
-                   block_cell_shared_owned_space.min(d) );
+                   grid_cell_shared_owned_space.min(d) );
         EXPECT_EQ( array_cell_shared_owned_space.max(d),
-                   block_cell_shared_owned_space.max(d) );
+                   grid_cell_shared_owned_space.max(d) );
     }
     EXPECT_EQ( array_cell_shared_owned_space.min(3), 0 );
     EXPECT_EQ( array_cell_shared_owned_space.max(3), dofs_per_cell );
@@ -174,14 +174,14 @@ void layoutTest()
     // Check the shared ghosted index_space.
     auto array_cell_shared_ghosted_space =
         cell_layout->sharedIndexSpace(Ghost(),1,1,1);
-    auto block_cell_shared_ghosted_space =
-        cell_layout->block()->sharedIndexSpace( Ghost(), Cell(), 1, 1, 1 );
+    auto grid_cell_shared_ghosted_space =
+        cell_layout->localGrid()->sharedIndexSpace( Ghost(), Cell(), 1, 1, 1 );
     for ( int d = 0; d < 3; ++d )
     {
         EXPECT_EQ( array_cell_shared_ghosted_space.min(d),
-                   block_cell_shared_ghosted_space.min(d) );
+                   grid_cell_shared_ghosted_space.min(d) );
         EXPECT_EQ( array_cell_shared_ghosted_space.max(d),
-                   block_cell_shared_ghosted_space.max(d) );
+                   grid_cell_shared_ghosted_space.max(d) );
     }
     EXPECT_EQ( array_cell_shared_ghosted_space.min(3), 0 );
     EXPECT_EQ( array_cell_shared_ghosted_space.max(3), dofs_per_cell );

--- a/unit_test/tstBovWriter.hpp
+++ b/unit_test/tstBovWriter.hpp
@@ -69,7 +69,7 @@ void writeTest()
     Kokkos::parallel_for(
         "fill_cell_field",
         createExecutionPolicy(
-            cell_layout->block()->indexSpace(Own(),Cell(),Local()),
+            cell_layout->localGrid()->indexSpace(Own(),Cell(),Local()),
             TEST_EXECSPACE() ),
         KOKKOS_LAMBDA( const int i, const int j, const int k ){
             cell_data( i, j, k, 0 ) = i + off_i + j + off_j + k + off_k;
@@ -83,7 +83,7 @@ void writeTest()
     Kokkos::parallel_for(
         "fill_node_field",
         createExecutionPolicy(
-            node_layout->block()->indexSpace(Own(),Node(),Local()),
+            node_layout->localGrid()->indexSpace(Own(),Node(),Local()),
             TEST_EXECSPACE() ),
         KOKKOS_LAMBDA( const int i, const int j, const int k ){
             node_data( i, j, k, Dim::I ) = i + off_i;

--- a/unit_test/tstPointSet.hpp
+++ b/unit_test/tstPointSet.hpp
@@ -15,7 +15,7 @@
 #include <Cajita_GlobalMesh.hpp>
 #include <Cajita_GlobalGrid.hpp>
 #include <Cajita_UniformDimPartitioner.hpp>
-#include <Cajita_Block.hpp>
+#include <Cajita_LocalGrid.hpp>
 #include <Cajita_LocalMesh.hpp>
 #include <Cajita_Splines.hpp>
 #include <Cajita_PointSet.hpp>
@@ -51,14 +51,14 @@ void pointSetTest()
                                          is_dim_periodic,
                                          partitioner );
 
-    // Create a  grid block.
+    // Create a local grid.
     int halo_width = 1;
-    auto block = createBlock( global_grid, halo_width );
-    auto local_mesh = createLocalMesh<TEST_DEVICE>( *block );
+    auto local_grid = createLocalGrid( global_grid, halo_width );
+    auto local_mesh = createLocalMesh<TEST_DEVICE>( *local_grid );
 
     // Create a point in the center of every cell.
     auto cell_space =
-        block->indexSpace( Own(), Cell(), Local() );
+        local_grid->indexSpace( Own(), Cell(), Local() );
     int num_point = cell_space.size();
     Kokkos::View<double*[3],TEST_DEVICE> points(
         Kokkos::ViewAllocateWithoutInitializing("points"), num_point );
@@ -81,7 +81,7 @@ void pointSetTest()
 
     // Create a point set with linear spline interpolation to the nodes.
     auto point_set = createPointSet(
-        points, num_point, num_point, *block, Node(), Spline<1>() );
+        points, num_point, num_point, *local_grid, Node(), Spline<1>() );
 
     // Check the point set data.
     EXPECT_EQ( point_set.num_point, num_point );

--- a/unit_test/tstStructuredSolver.hpp
+++ b/unit_test/tstStructuredSolver.hpp
@@ -46,12 +46,12 @@ void poissonTest( const std::string& solver_type, const std::string& precond_typ
                                          is_dim_periodic,
                                          partitioner );
 
-    // Create a block.
-    auto block = createBlock( global_grid, 0 );
-    auto owned_space = block->indexSpace(Own(),Cell(),Local());
+    // Create a local grid.
+    auto local_mesh = createLocalGrid( global_grid, 0 );
+    auto owned_space = local_mesh->indexSpace(Own(),Cell(),Local());
 
     // Create the RHS.
-    auto vector_layout = createArrayLayout( block, 1, Cell() );
+    auto vector_layout = createArrayLayout( local_mesh, 1, Cell() );
     auto rhs = createArray<double,TEST_DEVICE>( "rhs", vector_layout );
     ArrayOp::assign( *rhs, 1.0, Own() );
 
@@ -69,7 +69,7 @@ void poissonTest( const std::string& solver_type, const std::string& precond_typ
     solver->setMatrixStencil( stencil );
 
     // Create the matrix entries. The stencil is defined over cells.
-    auto matrix_entry_layout = createArrayLayout( block, 7, Cell() );
+    auto matrix_entry_layout = createArrayLayout( local_mesh, 7, Cell() );
     auto matrix_entries = createArray<double,TEST_DEVICE>(
         "matrix_entries", matrix_entry_layout );
     auto entry_view = matrix_entries->view();


### PR DESCRIPTION
This makes the naming conventions between mesh (geometry) and grid (indexing) consistent. The term "Block" is still currently used to define a partition.