### PR TITLE
Local Interpolation Kernels

### DIFF
--- a/src/Cajita_Interpolation.hpp
+++ b/src/Cajita_Interpolation.hpp
@@ -26,380 +26,330 @@
 namespace Cajita
 {
 //---------------------------------------------------------------------------//
-// Point-to-Grid
+// LOCAL INTERPOLATION
+//---------------------------------------------------------------------------//
+
+//---------------------------------------------------------------------------//
+// local grid-to-point.
+//---------------------------------------------------------------------------//
+namespace G2P
+{
 //---------------------------------------------------------------------------//
 /*!
-  \brief Local Point-to-Grid interpolation.
-
-  \tparam PointEvalFunctor Functor type used to evaluate the interpolated data
-  for a given point at a given entity.
-
-  \tparam PointCoordinates Container type with view traits containing the 3-d
-  point coordinates. Will be indexed as (point,dim).
-
-  \tparam ArrayScalar The scalar type used for the interpolated data.
-
-  \tparam MeshScalar The scalar type used for the geometry/interpolation data.
-
-  \tparam EntityType The entitytype to which the points will interpolate.
-
-  \tparam SplineOrder The order of spline interpolation to use.
-
-  \tparam DeviceType The device type to use for interplation
-
-  \tparam ArrayParams Parameters for the array type.
-
-  \param functor A functor that interpolates from a given point to a given
-  entity.
-
-  \param points The points over which to perform the interpolation. Will be
-  indexed as (point,dim). The subset of indices in each point's interpolation
-  stencil must be contained within the local grid that will be used for the
-  interpolation
-
-  \param num_point The number of points. This is the size of the first
-  dimension of points.
-
-  \param Spline to use for interpolation.
-
-  \param halo The halo associated with the grid array. This hallo will be used
-  to scatter the interpolated data.
-
-  \param array The grid array to which the point data will be interpolated.
+  \brief Interpolate a scalar value to a point.
+  \param view The view of scalar grid data from which to interpolate.
+  \param sd The spline data to use for the interpolation.
+  \param result The scalar value at the point.
 */
-template <class PointEvalFunctor, class PointCoordinates, class ArrayScalar,
-          class MeshScalar, class EntityType, int SplineOrder, class DeviceType,
-          class... ArrayParams>
-void p2g( const PointEvalFunctor &functor, const PointCoordinates &points,
-          const std::size_t num_point, Spline<SplineOrder>,
-          const Halo<ArrayScalar, DeviceType> &halo,
-          Array<ArrayScalar, EntityType, UniformMesh<MeshScalar>,
-                ArrayParams...> &array )
+template <class ViewType, class SplineDataType, class PointDataType>
+KOKKOS_INLINE_FUNCTION void
+value( const ViewType &view, const SplineDataType &sd, PointDataType &result,
+       typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
+                               void *>::type = 0 )
 {
-    using array_type =
-        Array<ArrayScalar, EntityType, UniformMesh<MeshScalar>, ArrayParams...>;
-    static_assert(
-        std::is_same<DeviceType, typename array_type::device_type>::value,
-        "Mismatching points/array device types." );
+    result = 0.0;
 
-    using execution_space = typename DeviceType::execution_space;
-
-    // Create the local mesh.
-    auto local_mesh =
-        createLocalMesh<DeviceType>( *( array.layout()->localGrid() ) );
-
-    // Create a scatter view of the array.
-    auto array_view = array.view();
-    auto array_sv = Kokkos::Experimental::create_scatter_view( array_view );
-
-    // Loop over points and interpolate to the grid.
-    Kokkos::parallel_for(
-        "p2g", Kokkos::RangePolicy<execution_space>( 0, num_point ),
-        KOKKOS_LAMBDA( const int p ) {
-            // Create a local scatter result.
-            ArrayScalar result[PointEvalFunctor::value_count];
-
-            // Access the scatter view.
-            auto array_access = array_sv.access();
-
-            // Get the point coordinates.
-            MeshScalar px[3] = {points( p, Dim::I ), points( p, Dim::J ),
-                                points( p, Dim::K )};
-
-            // Create the local spline data.
-            using sd_type = SplineData<MeshScalar, SplineOrder, EntityType>;
-            sd_type sd;
-            evaluateSpline( local_mesh, px, sd );
-
-            // Loop over the point stencil and evaluate the functor at each
-            // entity in the stencil and apply each stencil result to the
-            // array.
-            for ( int i = 0; i < sd_type::num_knot; ++i )
-                for ( int j = 0; j < sd_type::num_knot; ++j )
-                    for ( int k = 0; k < sd_type::num_knot; ++k )
-                    {
-                        functor( sd, p, i, j, k, result );
-
-                        for ( int d = 0; d < PointEvalFunctor::value_count;
-                              ++d )
-                            array_access( sd.s[Dim::I][i], sd.s[Dim::J][j],
-                                          sd.s[Dim::K][k], d ) += result[d];
-                    }
-        } );
-    Kokkos::Experimental::contribute( array_view, array_sv );
-
-    // Scatter interpolation contributions in the halo back to their owning
-    // ranks.
-    halo.scatter( array );
+    for ( int i = 0; i < SplineDataType::num_knot; ++i )
+        for ( int j = 0; j < SplineDataType::num_knot; ++j )
+            for ( int k = 0; k < SplineDataType::num_knot; ++k )
+                result += view( sd.s[Dim::I][i], sd.s[Dim::J][j],
+                                sd.s[Dim::K][k], 0 ) *
+                          sd.w[Dim::I][i] * sd.w[Dim::J][j] * sd.w[Dim::K][k];
 }
 
 //---------------------------------------------------------------------------//
 /*!
-  \brief Point-to-grid scalar value functor.
-
-  Interpolates a scalar function from points to entities with a given
-  multiplier such that:
-
-  f_ijk = multiplier * \sum_p weight_{pijk} * f_p
-
-  Note that a functor implements the interpolation contribution between a
-  single point, indexed with a local p index, and a single entity, indexed
-  with local ijk indices. A single, potentially multi-dimensional result is
-  provided as the contribution.
+  \brief Interpolate a vector value to a point.
+  \param view The view of vector grid data from which to interpolate.
+  \param sd The spline data to use for the interpolation.
+  \param result The vector value at the point.
 */
-template <class ViewType>
-struct ScalarValueP2G
+template <class ViewType, class SplineDataType, class PointDataType>
+KOKKOS_INLINE_FUNCTION void
+value( const ViewType &view, const SplineDataType &sd, PointDataType result[3],
+       typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
+                               void *>::type = 0 )
 {
-    static constexpr int value_count = 1;
-    using value_type = typename ViewType::value_type;
+    for ( int d = 0; d < 3; ++d )
+        result[d] = 0.0;
 
-    ViewType _x;
-    value_type _multiplier;
-
-    ScalarValueP2G( const ViewType &x, const value_type multiplier )
-        : _x( x )
-        , _multiplier( multiplier )
-    {
-        static_assert( 1 == ViewType::Rank, "View must be of scalars" );
-    }
-
-    template <class SplineDataType>
-    KOKKOS_INLINE_FUNCTION void
-    operator()( const SplineDataType &sd, const int p, const int i, const int j,
-                const int k, value_type *result ) const
-    {
-        result[0] = _multiplier * _x( p ) * sd.w[Dim::I][i] * sd.w[Dim::J][j] *
-                    sd.w[Dim::K][k];
-    }
-};
-
-template <class ViewType>
-ScalarValueP2G<ViewType>
-createScalarValueP2G( const ViewType &x,
-                      const typename ViewType::value_type &multiplier )
-{
-    return ScalarValueP2G<ViewType>( x, multiplier );
+    for ( int i = 0; i < SplineDataType::num_knot; ++i )
+        for ( int j = 0; j < SplineDataType::num_knot; ++j )
+            for ( int k = 0; k < SplineDataType::num_knot; ++k )
+                for ( int d = 0; d < 3; ++d )
+                    result[d] += view( sd.s[Dim::I][i], sd.s[Dim::J][j],
+                                       sd.s[Dim::K][k], d ) *
+                                 sd.w[Dim::I][i] * sd.w[Dim::J][j] *
+                                 sd.w[Dim::K][k];
 }
 
 //---------------------------------------------------------------------------//
 /*!
-  \brief Point-to-grid vector value functor.
-
-  Interpolates a vector function from points to entities with a given
-  multiplier such that:
-
-  f_{ijkd} = multiplier * \sum_p weight_{pijk} * f_{pd}
-
-  Note that a functor implements the interpolation contribution between a
-  single point, indexed with a local p index, and a single entity, indexed
-  with local ijk indices. A single, potentially multi-dimensional result is
-  provided as the contribution.
+  \brief Interpolate a scalar gradient to a point.
+  \param view The view of scalar grid data from which to interpolate.
+  \param sd The spline data to use for the interpolation.
+  \param result The scalar gradient at the point.
 */
-template <class ViewType>
-struct VectorValueP2G
+template <class ViewType, class SplineDataType, class PointDataType>
+KOKKOS_INLINE_FUNCTION void
+gradient( const ViewType &view, const SplineDataType &sd,
+          PointDataType result[3],
+          typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
+                                  void *>::type = 0 )
 {
-    static constexpr int value_count = 3;
-    using value_type = typename ViewType::value_type;
+    for ( int d = 0; d < 3; ++d )
+        result[d] = 0.0;
 
-    ViewType _x;
-    value_type _multiplier;
+    for ( int i = 0; i < SplineDataType::num_knot; ++i )
+        for ( int j = 0; j < SplineDataType::num_knot; ++j )
+            for ( int k = 0; k < SplineDataType::num_knot; ++k )
+            {
+                result[Dim::I] += view( sd.s[Dim::I][i], sd.s[Dim::J][j],
+                                        sd.s[Dim::K][k], 0 ) *
+                                  sd.g[Dim::I][i] * sd.w[Dim::J][j] *
+                                  sd.w[Dim::K][k];
 
-    VectorValueP2G( const ViewType &x, const value_type multiplier )
-        : _x( x )
-        , _multiplier( multiplier )
-    {
-        static_assert( 2 == ViewType::Rank, "View must be of vectors" );
-    }
+                result[Dim::J] += view( sd.s[Dim::I][i], sd.s[Dim::J][j],
+                                        sd.s[Dim::K][k], 0 ) *
+                                  sd.w[Dim::I][i] * sd.g[Dim::J][j] *
+                                  sd.w[Dim::K][k];
 
-    template <class SplineDataType>
-    KOKKOS_INLINE_FUNCTION void
-    operator()( const SplineDataType &sd, const int p, const int i, const int j,
-                const int k, value_type *result ) const
-    {
-        value_type weight =
-            _multiplier * sd.w[Dim::I][i] * sd.w[Dim::J][j] * sd.w[Dim::K][k];
-        for ( int d = 0; d < 3; ++d )
-            result[d] = weight * _x( p, d );
-    }
-};
-
-template <class ViewType>
-VectorValueP2G<ViewType>
-createVectorValueP2G( const ViewType &x,
-                      const typename ViewType::value_type &multiplier )
-{
-    return VectorValueP2G<ViewType>( x, multiplier );
+                result[Dim::K] += view( sd.s[Dim::I][i], sd.s[Dim::J][j],
+                                        sd.s[Dim::K][k], 0 ) *
+                                  sd.w[Dim::I][i] * sd.w[Dim::J][j] *
+                                  sd.g[Dim::K][k];
+            }
 }
 
 //---------------------------------------------------------------------------//
 /*!
-  \brief Point-to-grid scalar gradient functor.
-
-  Interpolates the gradient of a scalar function from points to entities with
-  a given multiplier such that:
-
-  f_{ijkd} = multiplier * \sum_p grad_weight_{pijkd} * f_p
-
-  Note that a functor implements the interpolation contribution between a
-  single point, indexed with a local p index, and a single entity, indexed
-  with local ijk indices. A single, potentially multi-dimensional result is
-  provided as the contribution.
+  \brief Interpolate a vector gradient to a point.
+  \param view The view of vector grid data from which to interpolate.
+  \param sd The spline data to use for the interpolation.
+  \param result The vector gradient at the point.
 */
-template <class ViewType>
-struct ScalarGradientP2G
+template <class ViewType, class SplineDataType, class PointDataType>
+KOKKOS_INLINE_FUNCTION void
+gradient( const ViewType &view, const SplineDataType &sd,
+          PointDataType result[3][3],
+          typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
+                                  void *>::type = 0 )
 {
-    static constexpr int value_count = 3;
-    using value_type = typename ViewType::value_type;
-
-    ViewType _x;
-    value_type _multiplier;
-
-    ScalarGradientP2G( const ViewType &x, const value_type multiplier )
-        : _x( x )
-        , _multiplier( multiplier )
-    {
-        static_assert( 1 == ViewType::Rank, "View must be of scalars" );
-    }
-
-    template <class SplineDataType>
-    KOKKOS_INLINE_FUNCTION void
-    operator()( const SplineDataType &sd, const int p, const int i, const int j,
-                const int k, value_type *result ) const
-    {
-        auto mx = _multiplier * _x( p );
-        result[Dim::I] =
-            mx * sd.g[Dim::I][i] * sd.w[Dim::J][j] * sd.w[Dim::K][k];
-        result[Dim::J] =
-            mx * sd.w[Dim::I][i] * sd.g[Dim::J][j] * sd.w[Dim::K][k];
-        result[Dim::K] =
-            mx * sd.w[Dim::I][i] * sd.w[Dim::J][j] * sd.g[Dim::K][k];
-    }
-};
-
-template <class ViewType>
-ScalarGradientP2G<ViewType>
-createScalarGradientP2G( const ViewType &x,
-                         const typename ViewType::value_type &multiplier )
-{
-    return ScalarGradientP2G<ViewType>( x, multiplier );
-}
-
-//---------------------------------------------------------------------------//
-/*!
-  \brief Point-to-grid vector divergence functor.
-
-  Interpolates the divergence of a vector function from points to entities
-  with a given multiplier such that:
-
-  f_ijk = multiplier * \sum_d \sum_p grad_weight_{pijkd} * f_{pd}
-
-  Note that a functor implements the interpolation contribution between a
-  single point, indexed with a local p index, and a single entity, indexed
-  with local ijk indices. A single, potentially multi-dimensional result is
-  provided as the contribution.
-*/
-template <class ViewType>
-struct VectorDivergenceP2G
-{
-    static constexpr int value_count = 1;
-    using value_type = typename ViewType::value_type;
-
-    ViewType _x;
-    value_type _multiplier;
-
-    VectorDivergenceP2G( const ViewType &x, const value_type multiplier )
-        : _x( x )
-        , _multiplier( multiplier )
-    {
-        static_assert( 2 == ViewType::Rank, "View must be of vectors" );
-    }
-
-    template <class SplineDataType>
-    KOKKOS_INLINE_FUNCTION void
-    operator()( const SplineDataType &sd, const int p, const int i, const int j,
-                const int k, value_type *result ) const
-    {
-        result[0] = ( _x( p, Dim::I ) * sd.g[Dim::I][i] * sd.w[Dim::J][j] *
-                          sd.w[Dim::K][k] +
-
-                      _x( p, Dim::J ) * sd.w[Dim::I][i] * sd.g[Dim::J][j] *
-                          sd.w[Dim::K][k] +
-
-                      _x( p, Dim::K ) * sd.w[Dim::I][i] * sd.w[Dim::J][j] *
-                          sd.g[Dim::K][k] ) *
-                    _multiplier;
-    }
-};
-
-template <class ViewType>
-VectorDivergenceP2G<ViewType>
-createVectorDivergenceP2G( const ViewType &x,
-                           const typename ViewType::value_type &multiplier )
-{
-    return VectorDivergenceP2G<ViewType>( x, multiplier );
-}
-
-//---------------------------------------------------------------------------//
-/*!
-  \brief Point-to-grid tensor divergence functor.
-
-  Interpolates the divergence of a tensor function from points to entities
-  with a given multiplier such that:
-
-  f_ijkm = multiplier * \sum_n \sum_p grad_weight_{pijkn} * f_{pmn}
-
-  Note that a functor implements the interpolation contribution between a
-  single point, indexed with a local p index, and a single entity, indexed
-  with local ijk indices. A single, potentially multi-dimensional result is
-  provided as the contribution.
-*/
-template <class ViewType>
-struct TensorDivergenceP2G
-{
-    static constexpr int value_count = 3;
-    using value_type = typename ViewType::value_type;
-
-    ViewType _x;
-    value_type _multiplier;
-
-    TensorDivergenceP2G( const ViewType &x, const value_type multiplier )
-        : _x( x )
-        , _multiplier( multiplier )
-    {
-        static_assert( 3 == ViewType::Rank, "View must be of tensors" );
-    }
-
-    template <class SplineDataType>
-    KOKKOS_INLINE_FUNCTION void
-    operator()( const SplineDataType &sd, const int p, const int i, const int j,
-                const int k, value_type *result ) const
-    {
-        for ( int d = 0; d < 3; ++d )
-            result[d] = 0.0;
-
-        double rg[3] = {sd.g[Dim::I][i] * sd.w[Dim::J][j] * sd.w[Dim::K][k],
-                        sd.w[Dim::I][i] * sd.g[Dim::J][j] * sd.w[Dim::K][k],
-                        sd.w[Dim::I][i] * sd.w[Dim::J][j] * sd.g[Dim::K][k]};
-
+    for ( int d0 = 0; d0 < 3; ++d0 )
         for ( int d1 = 0; d1 < 3; ++d1 )
-        {
-            auto mg = _multiplier * rg[d1];
-            for ( int d0 = 0; d0 < 3; ++d0 )
-                result[d0] += mg * _x( p, d0, d1 );
-        }
-    }
-};
+            result[d0][d1] = 0.0;
 
-template <class ViewType>
-TensorDivergenceP2G<ViewType>
-createTensorDivergenceP2G( const ViewType &x,
-                           const typename ViewType::value_type &multiplier )
-{
-    return TensorDivergenceP2G<ViewType>( x, multiplier );
+    for ( int i = 0; i < SplineDataType::num_knot; ++i )
+        for ( int j = 0; j < SplineDataType::num_knot; ++j )
+            for ( int k = 0; k < SplineDataType::num_knot; ++k )
+            {
+                typename SplineDataType::scalar_type rg[3] = {
+                    sd.g[Dim::I][i] * sd.w[Dim::J][j] * sd.w[Dim::K][k],
+                    sd.w[Dim::I][i] * sd.g[Dim::J][j] * sd.w[Dim::K][k],
+                    sd.w[Dim::I][i] * sd.w[Dim::J][j] * sd.g[Dim::K][k]};
+
+                for ( int d0 = 0; d0 < 3; ++d0 )
+                {
+                    typename ViewType::value_type mg = rg[d0];
+                    for ( int d1 = 0; d1 < 3; ++d1 )
+                        result[d0][d1] +=
+                            mg * view( sd.s[Dim::I][i], sd.s[Dim::J][j],
+                                       sd.s[Dim::K][k], d1 );
+                }
+            }
 }
 
 //---------------------------------------------------------------------------//
-// Grid-to-Point
+/*!
+  \brief Interpolate a vector divergence to a point.
+  \param view The view of vector grid data from which to interpolate.
+  \param sd The spline data to use for the interpolation.
+  \param result The vector divergence at the point.
+*/
+template <class ViewType, class SplineDataType, class PointDataType>
+KOKKOS_INLINE_FUNCTION void
+divergence( const ViewType &view, const SplineDataType &sd,
+            PointDataType &result,
+            typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
+                                    void *>::type = 0 )
+{
+    result = 0.0;
+
+    for ( int i = 0; i < SplineDataType::num_knot; ++i )
+        for ( int j = 0; j < SplineDataType::num_knot; ++j )
+            for ( int k = 0; k < SplineDataType::num_knot; ++k )
+                result +=
+                    view( sd.s[Dim::I][i], sd.s[Dim::J][j], sd.s[Dim::K][k],
+                          Dim::I ) *
+                        sd.g[Dim::I][i] * sd.w[Dim::J][j] * sd.w[Dim::K][k] +
+
+                    view( sd.s[Dim::I][i], sd.s[Dim::J][j], sd.s[Dim::K][k],
+                          Dim::J ) *
+                        sd.w[Dim::I][i] * sd.g[Dim::J][j] * sd.w[Dim::K][k] +
+
+                    view( sd.s[Dim::I][i], sd.s[Dim::J][j], sd.s[Dim::K][k],
+                          Dim::K ) *
+                        sd.w[Dim::I][i] * sd.w[Dim::J][j] * sd.g[Dim::K][k];
+}
+
+//---------------------------------------------------------------------------//
+
+} // end namespace G2P
+
+//---------------------------------------------------------------------------//
+// Local point-to-grid.
+//---------------------------------------------------------------------------//
+namespace P2G
+{
+//---------------------------------------------------------------------------//
+/*!
+  \brief Interpolate a scalar value to the grid.
+  \param point_data The scalar value to at the point interpolate to the grid.
+  \param sd The spline data to use for the interpolation.
+  \param view The view of scalar grid data to interpolate to.
+*/
+template <class PointDataType, class ViewType, class SplineDataType>
+KOKKOS_INLINE_FUNCTION void
+value( const PointDataType &point_data, const SplineDataType &sd,
+       const ViewType &view,
+       typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
+                               void *>::type = 0 )
+{
+    for ( int i = 0; i < SplineDataType::num_knot; ++i )
+        for ( int j = 0; j < SplineDataType::num_knot; ++j )
+            for ( int k = 0; k < SplineDataType::num_knot; ++k )
+                view( sd.s[Dim::I][i], sd.s[Dim::J][j], sd.s[Dim::K][k], 0 ) +=
+                    point_data * sd.w[Dim::I][i] * sd.w[Dim::J][j] *
+                    sd.w[Dim::K][k];
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Interpolate a vector value to the grid.
+  \param point_data The vector value at the point to interpolate to the grid.
+  \param sd The spline data to use for the interpolation.
+  \param view The view of vector grid data to interpolate to.
+*/
+template <class PointDataType, class ViewType, class SplineDataType>
+KOKKOS_INLINE_FUNCTION void
+value( const PointDataType point_data[3], const SplineDataType &sd,
+       const ViewType &view,
+       typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
+                               void *>::type = 0 )
+{
+    for ( int i = 0; i < SplineDataType::num_knot; ++i )
+        for ( int j = 0; j < SplineDataType::num_knot; ++j )
+            for ( int k = 0; k < SplineDataType::num_knot; ++k )
+                for ( int d = 0; d < 3; ++d )
+                    view( sd.s[Dim::I][i], sd.s[Dim::J][j], sd.s[Dim::K][k],
+                          d ) += point_data[d] * sd.w[Dim::I][i] *
+                                 sd.w[Dim::J][j] * sd.w[Dim::K][k];
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Interpolate the gradient of a scalar to the grid.
+  \param point_data The scalar at the point who's gradient to interpolate to the
+  grid. \param sd The spline data to use for the interpolation. \param view The
+  view of scalar gradient grid data to interpolate to.
+*/
+template <class PointDataType, class ViewType, class SplineDataType>
+KOKKOS_INLINE_FUNCTION void gradient( const PointDataType point_data,
+                                      const SplineDataType &sd,
+                                      const ViewType &view )
+{
+    for ( int i = 0; i < SplineDataType::num_knot; ++i )
+        for ( int j = 0; j < SplineDataType::num_knot; ++j )
+            for ( int k = 0; k < SplineDataType::num_knot; ++k )
+            {
+                view( sd.s[Dim::I][i], sd.s[Dim::J][j], sd.s[Dim::K][k],
+                      Dim::I ) += point_data * sd.g[Dim::I][i] *
+                                  sd.w[Dim::J][j] * sd.w[Dim::K][k];
+
+                view( sd.s[Dim::I][i], sd.s[Dim::J][j], sd.s[Dim::K][k],
+                      Dim::J ) += point_data * sd.w[Dim::I][i] *
+                                  sd.g[Dim::J][j] * sd.w[Dim::K][k];
+
+                view( sd.s[Dim::I][i], sd.s[Dim::J][j], sd.s[Dim::K][k],
+                      Dim::K ) += point_data * sd.w[Dim::I][i] *
+                                  sd.w[Dim::J][j] * sd.g[Dim::K][k];
+            }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Interpolate the divergence of a vector to the grid.
+  \param point_data The vector at the point who's divergence to interpolate to
+  the grid. \param sd The spline data to use for the interpolation. \param view
+  The view of vector divergence grid data to interpolate to.
+*/
+template <class PointDataType, class ViewType, class SplineDataType>
+KOKKOS_INLINE_FUNCTION void
+divergence( const PointDataType point_data[3], const SplineDataType &sd,
+            const ViewType &view,
+            typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
+                                    void *>::type = 0 )
+{
+    for ( int i = 0; i < SplineDataType::num_knot; ++i )
+        for ( int j = 0; j < SplineDataType::num_knot; ++j )
+            for ( int k = 0; k < SplineDataType::num_knot; ++k )
+            {
+                PointDataType result = point_data[Dim::I] * sd.g[Dim::I][i] *
+                                           sd.w[Dim::J][j] * sd.w[Dim::K][k] +
+
+                                       point_data[Dim::J] * sd.w[Dim::I][i] *
+                                           sd.g[Dim::J][j] * sd.w[Dim::K][k] +
+
+                                       point_data[Dim::K] * sd.w[Dim::I][i] *
+                                           sd.w[Dim::J][j] * sd.g[Dim::K][k];
+
+                view( sd.s[Dim::I][i], sd.s[Dim::J][j], sd.s[Dim::K][k], 0 ) +=
+                    result;
+            }
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Interpolate the divergence of a tensor to the grid.
+  \param point_data The tensor at the point who's divergence to interpolate to
+  the grid. \param sd The spline data to use for the interpolation. \param view
+  The view of tensor divergence grid data to interpolate to.
+*/
+template <class ViewType, class SplineDataType, class PointDataType>
+KOKKOS_INLINE_FUNCTION void
+divergence( const PointDataType point_data[3][3], const SplineDataType &sd,
+            const ViewType &view,
+            typename std::enable_if<( std::rank<PointDataType>::value == 0 ),
+                                    void *>::type = 0 )
+{
+    for ( int i = 0; i < SplineDataType::num_knot; ++i )
+        for ( int j = 0; j < SplineDataType::num_knot; ++j )
+            for ( int k = 0; k < SplineDataType::num_knot; ++k )
+            {
+                typename SplineDataType::scalar_type rg[3] = {
+                    sd.g[Dim::I][i] * sd.w[Dim::J][j] * sd.w[Dim::K][k],
+                    sd.w[Dim::I][i] * sd.g[Dim::J][j] * sd.w[Dim::K][k],
+                    sd.w[Dim::I][i] * sd.w[Dim::J][j] * sd.g[Dim::K][k]};
+
+                for ( int d1 = 0; d1 < 3; ++d1 )
+                {
+                    for ( int d0 = 0; d0 < 3; ++d0 )
+                        view( sd.s[Dim::I][i], sd.s[Dim::J][j], sd.s[Dim::K][k],
+                              d0 ) += rg[d1] * point_data[d0][d1];
+                }
+            }
+}
+
+//---------------------------------------------------------------------------//
+
+} // end namespace P2G
+
+//---------------------------------------------------------------------------//
+// GLOBAL INTERPOLATION
+//---------------------------------------------------------------------------//
+
+//---------------------------------------------------------------------------//
+// Global grid-to-Point
 //---------------------------------------------------------------------------//
 /*
  \brief Local Grid-to-Point interpolation.
@@ -471,9 +421,6 @@ void g2p( const Array<ArrayScalar, EntityType, UniformMesh<MeshScalar>,
     Kokkos::parallel_for(
         "g2p", Kokkos::RangePolicy<execution_space>( 0, num_point ),
         KOKKOS_LAMBDA( const int p ) {
-            // Create local gather values.
-            ArrayScalar values[PointEvalFunctor::value_count];
-
             // Get the point coordinates.
             MeshScalar px[3] = {points( p, Dim::I ), points( p, Dim::J ),
                                 points( p, Dim::K )};
@@ -483,20 +430,8 @@ void g2p( const Array<ArrayScalar, EntityType, UniformMesh<MeshScalar>,
             sd_type sd;
             evaluateSpline( local_mesh, px, sd );
 
-            // Loop over the point stencil and interpolate the grid data to
-            // the points.
-            for ( int i = 0; i < sd_type::num_knot; ++i )
-                for ( int j = 0; j < sd_type::num_knot; ++j )
-                    for ( int k = 0; k < sd_type::num_knot; ++k )
-                    {
-                        for ( int d = 0; d < PointEvalFunctor::value_count;
-                              ++d )
-                            values[d] =
-                                array_view( sd.s[Dim::I][i], sd.s[Dim::J][j],
-                                            sd.s[Dim::K][k], d );
-
-                        functor( sd, p, i, j, k, values );
-                    }
+            // Evaluate the functor.
+            functor( sd, p, array_view );
         } );
 }
 
@@ -508,16 +443,10 @@ void g2p( const Array<ArrayScalar, EntityType, UniformMesh<MeshScalar>,
   multiplier such that:
 
   f_p = multiplier * \sum_{ijk} weight_{pijk} * f_{ijk}
-
-  Note that a functor implements the interpolation contribution between a
-  single point, indexed with a local p index, and a single entity, indexed
-  with local ijk indices. A single, potentially multi-dimensional result is
-  provided as the contribution.
 */
 template <class ViewType>
 struct ScalarValueG2P
 {
-    static constexpr int value_count = 1;
     using value_type = typename ViewType::value_type;
 
     ViewType _x;
@@ -530,13 +459,14 @@ struct ScalarValueG2P
         static_assert( 1 == ViewType::Rank, "View must be of scalars" );
     }
 
-    template <class SplineDataType>
-    KOKKOS_INLINE_FUNCTION void
-    operator()( const SplineDataType &sd, const int p, const int i, const int j,
-                const int k, const value_type *values ) const
+    template <class SplineDataType, class GridViewType>
+    KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType &sd,
+                                            const int p,
+                                            const GridViewType view ) const
     {
-        _x( p ) += _multiplier * values[0] * sd.w[Dim::I][i] * sd.w[Dim::J][j] *
-                   sd.w[Dim::K][k];
+        value_type result;
+        G2P::value( view, sd, result );
+        _x( p ) += _multiplier * result;
     }
 };
 
@@ -556,16 +486,10 @@ createScalarValueG2P( const ViewType &x,
   multiplier such that:
 
   f_{pd} = multiplier * \sum_{ijk} weight_{pijk} * f_{ijkd}
-
-  Note that a functor implements the interpolation contribution between a
-  single point, indexed with a local p index, and a single entity, indexed
-  with local ijk indices. A single, potentially multi-dimensional result is
-  provided as the contribution.
 */
 template <class ViewType>
 struct VectorValueG2P
 {
-    static constexpr int value_count = 3;
     using value_type = typename ViewType::value_type;
 
     ViewType _x;
@@ -578,15 +502,15 @@ struct VectorValueG2P
         static_assert( 2 == ViewType::Rank, "View must be of vectors" );
     }
 
-    template <class SplineDataType>
-    KOKKOS_INLINE_FUNCTION void
-    operator()( const SplineDataType &sd, const int p, const int i, const int j,
-                const int k, const value_type *values ) const
+    template <class SplineDataType, class GridViewType>
+    KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType &sd,
+                                            const int p,
+                                            const GridViewType view ) const
     {
-        value_type weight =
-            _multiplier * sd.w[Dim::I][i] * sd.w[Dim::J][j] * sd.w[Dim::K][k];
+        value_type result[3];
+        G2P::value( view, sd, result );
         for ( int d = 0; d < 3; ++d )
-            _x( p, d ) += weight * values[d];
+            _x( p, d ) += _multiplier * result[d];
     }
 };
 
@@ -606,16 +530,10 @@ createVectorValueG2P( const ViewType &x,
   a given multiplier such that:
 
   f_{pd} = multiplier * \sum_{ijk} grad_weight_{pijkd} * f_{ijk}
-
-  Note that a functor implements the interpolation contribution between a
-  single point, indexed with a local p index, and a single entity, indexed
-  with local ijk indices. A single, potentially multi-dimensional result is
-  provided as the contribution.
 */
 template <class ViewType>
 struct ScalarGradientG2P
 {
-    static constexpr int value_count = 1;
     using value_type = typename ViewType::value_type;
 
     ViewType _x;
@@ -628,18 +546,15 @@ struct ScalarGradientG2P
         static_assert( 2 == ViewType::Rank, "View must be of vectors" );
     }
 
-    template <class SplineDataType>
-    KOKKOS_INLINE_FUNCTION void
-    operator()( const SplineDataType &sd, const int p, const int i, const int j,
-                const int k, const value_type *values ) const
+    template <class SplineDataType, class GridViewType>
+    KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType &sd,
+                                            const int p,
+                                            const GridViewType view ) const
     {
-        auto mx = _multiplier * values[0];
-        _x( p, Dim::I ) +=
-            mx * sd.g[Dim::I][i] * sd.w[Dim::J][j] * sd.w[Dim::K][k];
-        _x( p, Dim::J ) +=
-            mx * sd.w[Dim::I][i] * sd.g[Dim::J][j] * sd.w[Dim::K][k];
-        _x( p, Dim::K ) +=
-            mx * sd.w[Dim::I][i] * sd.w[Dim::J][j] * sd.g[Dim::K][k];
+        value_type result[3];
+        G2P::gradient( view, sd, result );
+        for ( int d = 0; d < 3; ++d )
+            _x( p, d ) += _multiplier * result[d];
     }
 };
 
@@ -659,16 +574,10 @@ createScalarGradientG2P( const ViewType &x,
   a given multiplier such that:
 
   f_{pmn} = multiplier * \sum_{ijk} grad_weight_{pijkm} * f_{ijkn}
-
-  Note that a functor implements the interpolation contribution between a
-  single point, indexed with a local p index, and a single entity, indexed
-  with local ijk indices. A single, potentially multi-dimensional result is
-  provided as the contribution.
 */
 template <class ViewType>
 struct VectorGradientG2P
 {
-    static constexpr int value_count = 3;
     using value_type = typename ViewType::value_type;
 
     ViewType _x;
@@ -681,21 +590,16 @@ struct VectorGradientG2P
         static_assert( 3 == ViewType::Rank, "View must be of tensors" );
     }
 
-    template <class SplineDataType>
-    KOKKOS_INLINE_FUNCTION void
-    operator()( const SplineDataType &sd, const int p, const int i, const int j,
-                const int k, const value_type *values ) const
+    template <class SplineDataType, class GridViewType>
+    KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType &sd,
+                                            const int p,
+                                            const GridViewType view ) const
     {
-        double rg[3] = {sd.g[Dim::I][i] * sd.w[Dim::J][j] * sd.w[Dim::K][k],
-                        sd.w[Dim::I][i] * sd.g[Dim::J][j] * sd.w[Dim::K][k],
-                        sd.w[Dim::I][i] * sd.w[Dim::J][j] * sd.g[Dim::K][k]};
-
+        value_type result[3][3];
+        G2P::gradient( view, sd, result );
         for ( int d0 = 0; d0 < 3; ++d0 )
-        {
-            auto mg = _multiplier * rg[d0];
             for ( int d1 = 0; d1 < 3; ++d1 )
-                _x( p, d0, d1 ) += mg * values[d1];
-        }
+                _x( p, d0, d1 ) += _multiplier * result[d0][d1];
     }
 };
 
@@ -715,16 +619,10 @@ createVectorGradientG2P( const ViewType &x,
   with a given multiplier such that:
 
   f_p = multiplier * \sum_d \sum_{ijk} grad_weight_{pijkd} * f_{ijkd}
-
-  Note that a functor implements the interpolation contribution between a
-  single point, indexed with a local p index, and a single entity, indexed
-  with local ijk indices. A single, potentially multi-dimensional result is
-  provided as the contribution.
 */
 template <class ViewType>
 struct VectorDivergenceG2P
 {
-    static constexpr int value_count = 3;
     using value_type = typename ViewType::value_type;
 
     ViewType _x;
@@ -737,20 +635,14 @@ struct VectorDivergenceG2P
         static_assert( 1 == ViewType::Rank, "View must be of scalars" );
     }
 
-    template <class SplineDataType>
-    KOKKOS_INLINE_FUNCTION void
-    operator()( const SplineDataType &sd, const int p, const int i, const int j,
-                const int k, const value_type *values ) const
+    template <class SplineDataType, class GridViewType>
+    KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType &sd,
+                                            const int p,
+                                            const GridViewType view ) const
     {
-        _x( p ) += ( values[Dim::I] * sd.g[Dim::I][i] * sd.w[Dim::J][j] *
-                         sd.w[Dim::K][k] +
-
-                     values[Dim::J] * sd.w[Dim::I][i] * sd.g[Dim::J][j] *
-                         sd.w[Dim::K][k] +
-
-                     values[Dim::K] * sd.w[Dim::I][i] * sd.w[Dim::J][j] *
-                         sd.g[Dim::K][k] ) *
-                   _multiplier;
+        value_type result;
+        G2P::divergence( view, sd, result );
+        _x( p ) += result * _multiplier;
     }
 };
 
@@ -760,6 +652,314 @@ createVectorDivergenceG2P( const ViewType &x,
                            const typename ViewType::value_type &multiplier )
 {
     return VectorDivergenceG2P<ViewType>( x, multiplier );
+}
+
+//---------------------------------------------------------------------------//
+// Global point-to-grid
+//---------------------------------------------------------------------------//
+/*!
+  \brief Local Point-to-Grid interpolation.
+
+  \tparam PointEvalFunctor Functor type used to evaluate the interpolated data
+  for a given point at a given entity.
+
+  \tparam PointCoordinates Container type with view traits containing the 3-d
+  point coordinates. Will be indexed as (point,dim).
+
+  \tparam ArrayScalar The scalar type used for the interpolated data.
+
+  \tparam MeshScalar The scalar type used for the geometry/interpolation data.
+
+  \tparam EntityType The entitytype to which the points will interpolate.
+
+  \tparam SplineOrder The order of spline interpolation to use.
+
+  \tparam DeviceType The device type to use for interplation
+
+  \tparam ArrayParams Parameters for the array type.
+
+  \param functor A functor that interpolates from a given point to a given
+  entity.
+
+  \param points The points over which to perform the interpolation. Will be
+  indexed as (point,dim). The subset of indices in each point's interpolation
+  stencil must be contained within the local grid that will be used for the
+  interpolation
+
+  \param num_point The number of points. This is the size of the first
+  dimension of points.
+
+  \param Spline to use for interpolation.
+
+  \param halo The halo associated with the grid array. This hallo will be used
+  to scatter the interpolated data.
+
+  \param array The grid array to which the point data will be interpolated.
+*/
+template <class PointEvalFunctor, class PointCoordinates, class ArrayScalar,
+          class MeshScalar, class EntityType, int SplineOrder, class DeviceType,
+          class... ArrayParams>
+void p2g( const PointEvalFunctor &functor, const PointCoordinates &points,
+          const std::size_t num_point, Spline<SplineOrder>,
+          const Halo<ArrayScalar, DeviceType> &halo,
+          Array<ArrayScalar, EntityType, UniformMesh<MeshScalar>,
+                ArrayParams...> &array )
+{
+    using array_type =
+        Array<ArrayScalar, EntityType, UniformMesh<MeshScalar>, ArrayParams...>;
+    static_assert(
+        std::is_same<DeviceType, typename array_type::device_type>::value,
+        "Mismatching points/array device types." );
+
+    using execution_space = typename DeviceType::execution_space;
+
+    // Create the local mesh.
+    auto local_mesh =
+        createLocalMesh<DeviceType>( *( array.layout()->localGrid() ) );
+
+    // Create a scatter view of the array.
+    auto array_view = array.view();
+    auto array_sv = Kokkos::Experimental::create_scatter_view( array_view );
+
+    // Loop over points and interpolate to the grid.
+    Kokkos::parallel_for(
+        "p2g", Kokkos::RangePolicy<execution_space>( 0, num_point ),
+        KOKKOS_LAMBDA( const int p ) {
+            // Get the point coordinates.
+            MeshScalar px[3] = {points( p, Dim::I ), points( p, Dim::J ),
+                                points( p, Dim::K )};
+
+            // Create the local spline data.
+            using sd_type = SplineData<MeshScalar, SplineOrder, EntityType>;
+            sd_type sd;
+            evaluateSpline( local_mesh, px, sd );
+
+            // Evaluate the functor.
+            auto array_access = array_sv.access();
+            functor( sd, p, array_access );
+        } );
+    Kokkos::Experimental::contribute( array_view, array_sv );
+
+    // Scatter interpolation contributions in the halo back to their owning
+    // ranks.
+    halo.scatter( array );
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Point-to-grid scalar value functor.
+
+  Interpolates a scalar function from points to entities with a given
+  multiplier such that:
+
+  f_ijk = multiplier * \sum_p weight_{pijk} * f_p
+*/
+template <class ViewType>
+struct ScalarValueP2G
+{
+    using value_type = typename ViewType::value_type;
+
+    ViewType _x;
+    value_type _multiplier;
+
+    ScalarValueP2G( const ViewType &x, const value_type multiplier )
+        : _x( x )
+        , _multiplier( multiplier )
+    {
+        static_assert( 1 == ViewType::Rank, "View must be of scalars" );
+    }
+
+    template <class SplineDataType, class GridViewType>
+    KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType &sd,
+                                            const int p,
+                                            const GridViewType view ) const
+    {
+        value_type point_data = _x( p ) * _multiplier;
+        P2G::value( point_data, sd, view );
+    }
+};
+
+template <class ViewType>
+ScalarValueP2G<ViewType>
+createScalarValueP2G( const ViewType &x,
+                      const typename ViewType::value_type &multiplier )
+{
+    return ScalarValueP2G<ViewType>( x, multiplier );
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Point-to-grid vector value functor.
+
+  Interpolates a vector function from points to entities with a given
+  multiplier such that:
+
+  f_{ijkd} = multiplier * \sum_p weight_{pijk} * f_{pd}
+*/
+template <class ViewType>
+struct VectorValueP2G
+{
+    using value_type = typename ViewType::value_type;
+
+    ViewType _x;
+    value_type _multiplier;
+
+    VectorValueP2G( const ViewType &x, const value_type multiplier )
+        : _x( x )
+        , _multiplier( multiplier )
+    {
+        static_assert( 2 == ViewType::Rank, "View must be of vectors" );
+    }
+
+    template <class SplineDataType, class GridViewType>
+    KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType &sd,
+                                            const int p,
+                                            const GridViewType view ) const
+    {
+        value_type point_data[3];
+        for ( int d = 0; d < 3; ++d )
+            point_data[d] = _multiplier * _x( p, d );
+        P2G::value( point_data, sd, view );
+    }
+};
+
+template <class ViewType>
+VectorValueP2G<ViewType>
+createVectorValueP2G( const ViewType &x,
+                      const typename ViewType::value_type &multiplier )
+{
+    return VectorValueP2G<ViewType>( x, multiplier );
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Point-to-grid scalar gradient functor.
+
+  Interpolates the gradient of a scalar function from points to entities with
+  a given multiplier such that:
+
+  f_{ijkd} = multiplier * \sum_p grad_weight_{pijkd} * f_p
+*/
+template <class ViewType>
+struct ScalarGradientP2G
+{
+    using value_type = typename ViewType::value_type;
+
+    ViewType _x;
+    value_type _multiplier;
+
+    ScalarGradientP2G( const ViewType &x, const value_type multiplier )
+        : _x( x )
+        , _multiplier( multiplier )
+    {
+        static_assert( 1 == ViewType::Rank, "View must be of scalars" );
+    }
+
+    template <class SplineDataType, class GridViewType>
+    KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType &sd,
+                                            const int p,
+                                            const GridViewType view ) const
+    {
+        value_type point_data = _x( p ) * _multiplier;
+        P2G::gradient( point_data, sd, view );
+    }
+};
+
+template <class ViewType>
+ScalarGradientP2G<ViewType>
+createScalarGradientP2G( const ViewType &x,
+                         const typename ViewType::value_type &multiplier )
+{
+    return ScalarGradientP2G<ViewType>( x, multiplier );
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Point-to-grid vector divergence functor.
+
+  Interpolates the divergence of a vector function from points to entities
+  with a given multiplier such that:
+
+  f_ijk = multiplier * \sum_d \sum_p grad_weight_{pijkd} * f_{pd}
+*/
+template <class ViewType>
+struct VectorDivergenceP2G
+{
+    using value_type = typename ViewType::value_type;
+
+    ViewType _x;
+    value_type _multiplier;
+
+    VectorDivergenceP2G( const ViewType &x, const value_type multiplier )
+        : _x( x )
+        , _multiplier( multiplier )
+    {
+        static_assert( 2 == ViewType::Rank, "View must be of vectors" );
+    }
+
+    template <class SplineDataType, class GridViewType>
+    KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType &sd,
+                                            const int p,
+                                            const GridViewType view ) const
+    {
+        value_type point_data[3];
+        for ( int d = 0; d < 3; ++d )
+            point_data[d] = _multiplier * _x( p, d );
+        P2G::divergence( point_data, sd, view );
+    }
+};
+
+template <class ViewType>
+VectorDivergenceP2G<ViewType>
+createVectorDivergenceP2G( const ViewType &x,
+                           const typename ViewType::value_type &multiplier )
+{
+    return VectorDivergenceP2G<ViewType>( x, multiplier );
+}
+
+//---------------------------------------------------------------------------//
+/*!
+  \brief Point-to-grid tensor divergence functor.
+
+  Interpolates the divergence of a tensor function from points to entities
+  with a given multiplier such that:
+
+  f_ijkm = multiplier * \sum_n \sum_p grad_weight_{pijkn} * f_{pmn}
+*/
+template <class ViewType>
+struct TensorDivergenceP2G
+{
+    using value_type = typename ViewType::value_type;
+
+    ViewType _x;
+    value_type _multiplier;
+
+    TensorDivergenceP2G( const ViewType &x, const value_type multiplier )
+        : _x( x )
+        , _multiplier( multiplier )
+    {
+        static_assert( 3 == ViewType::Rank, "View must be of tensors" );
+    }
+
+    template <class SplineDataType, class GridViewType>
+    KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType &sd,
+                                            const int p,
+                                            const GridViewType view ) const
+    {
+        value_type point_data[3][3];
+        for ( int d0 = 0; d0 < 3; ++d0 )
+            for ( int d1 = 0; d1 < 3; ++d1 )
+                point_data[d0][d1] = _multiplier * _x( p, d0, d1 );
+        P2G::divergence( point_data, sd, view );
+    }
+};
+
+template <class ViewType>
+TensorDivergenceP2G<ViewType>
+createTensorDivergenceP2G( const ViewType &x,
+                           const typename ViewType::value_type &multiplier )
+{
+    return TensorDivergenceP2G<ViewType>( x, multiplier );
 }
 
 //---------------------------------------------------------------------------//

--- a/src/Cajita_Interpolation.hpp
+++ b/src/Cajita_Interpolation.hpp
@@ -462,7 +462,7 @@ struct ScalarValueG2P
     template <class SplineDataType, class GridViewType>
     KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType &sd,
                                             const int p,
-                                            const GridViewType view ) const
+                                            const GridViewType &view ) const
     {
         value_type result;
         G2P::value( view, sd, result );
@@ -505,7 +505,7 @@ struct VectorValueG2P
     template <class SplineDataType, class GridViewType>
     KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType &sd,
                                             const int p,
-                                            const GridViewType view ) const
+                                            const GridViewType &view ) const
     {
         value_type result[3];
         G2P::value( view, sd, result );
@@ -549,7 +549,7 @@ struct ScalarGradientG2P
     template <class SplineDataType, class GridViewType>
     KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType &sd,
                                             const int p,
-                                            const GridViewType view ) const
+                                            const GridViewType &view ) const
     {
         value_type result[3];
         G2P::gradient( view, sd, result );
@@ -593,7 +593,7 @@ struct VectorGradientG2P
     template <class SplineDataType, class GridViewType>
     KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType &sd,
                                             const int p,
-                                            const GridViewType view ) const
+                                            const GridViewType &view ) const
     {
         value_type result[3][3];
         G2P::gradient( view, sd, result );
@@ -638,7 +638,7 @@ struct VectorDivergenceG2P
     template <class SplineDataType, class GridViewType>
     KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType &sd,
                                             const int p,
-                                            const GridViewType view ) const
+                                            const GridViewType &view ) const
     {
         value_type result;
         G2P::divergence( view, sd, result );
@@ -772,7 +772,7 @@ struct ScalarValueP2G
     template <class SplineDataType, class GridViewType>
     KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType &sd,
                                             const int p,
-                                            const GridViewType view ) const
+                                            const GridViewType &view ) const
     {
         value_type point_data = _x( p ) * _multiplier;
         P2G::value( point_data, sd, view );
@@ -814,7 +814,7 @@ struct VectorValueP2G
     template <class SplineDataType, class GridViewType>
     KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType &sd,
                                             const int p,
-                                            const GridViewType view ) const
+                                            const GridViewType &view ) const
     {
         value_type point_data[3];
         for ( int d = 0; d < 3; ++d )
@@ -858,7 +858,7 @@ struct ScalarGradientP2G
     template <class SplineDataType, class GridViewType>
     KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType &sd,
                                             const int p,
-                                            const GridViewType view ) const
+                                            const GridViewType &view ) const
     {
         value_type point_data = _x( p ) * _multiplier;
         P2G::gradient( point_data, sd, view );
@@ -900,7 +900,7 @@ struct VectorDivergenceP2G
     template <class SplineDataType, class GridViewType>
     KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType &sd,
                                             const int p,
-                                            const GridViewType view ) const
+                                            const GridViewType &view ) const
     {
         value_type point_data[3];
         for ( int d = 0; d < 3; ++d )
@@ -944,7 +944,7 @@ struct TensorDivergenceP2G
     template <class SplineDataType, class GridViewType>
     KOKKOS_INLINE_FUNCTION void operator()( const SplineDataType &sd,
                                             const int p,
-                                            const GridViewType view ) const
+                                            const GridViewType &view ) const
     {
         value_type point_data[3][3];
         for ( int d0 = 0; d0 < 3; ++d0 )

--- a/src/Cajita_Splines.hpp
+++ b/src/Cajita_Splines.hpp
@@ -361,6 +361,9 @@ struct SplineData
     static constexpr int num_knot = spline_type::num_knot;
     using entity_type = EntityType;
 
+    // Physical cell size.
+    Scalar dx;
+
     // Logical position.
     Scalar x[3];
 
@@ -386,7 +389,9 @@ evaluateSpline( const LocalMesh<Device, UniformMesh<Scalar>> &local_mesh,
     Scalar low_x[3];
     int low_id[3] = {0, 0, 0};
     local_mesh.coordinates( EntityType(), low_id, low_x );
-    Scalar rdx = 1.0 / local_mesh.measure( Edge<Dim::I>(), low_id );
+
+    data.dx = local_mesh.measure( Edge<Dim::I>(), low_id );
+    Scalar rdx = 1.0 / data.dx;
 
     for ( int d = 0; d < 3; ++d )
     {

--- a/src/Cajita_Types.hpp
+++ b/src/Cajita_Types.hpp
@@ -52,18 +52,21 @@ struct Face;
 template <>
 struct Face<Dim::I>
 {
+    static constexpr int dim = Dim::I;
 };
 
 // J-face tag.
 template <>
 struct Face<Dim::J>
 {
+    static constexpr int dim = Dim::J;
 };
 
 // K-face tag.
 template <>
 struct Face<Dim::K>
 {
+    static constexpr int dim = Dim::K;
 };
 
 // Mesh edge tags.
@@ -74,64 +77,81 @@ struct Edge;
 template <>
 struct Edge<Dim::I>
 {
+    static constexpr int dim = Dim::I;
 };
 
 // J-edge tag.
 template <>
 struct Edge<Dim::J>
 {
+    static constexpr int dim = Dim::J;
 };
 
 // K-edge tag.
 template <>
 struct Edge<Dim::K>
 {
+    static constexpr int dim = Dim::K;
 };
 
-// Type checker.
+// Type checkers.
+template <class T>
+struct isCell : public std::false_type
+{
+};
+
+template <>
+struct isCell<Cell> : public std::true_type
+{
+};
+
+template <>
+struct isCell<const Cell> : public std::true_type
+{
+};
 
 template <class T>
-struct isEntityType : public std::false_type
+struct isNode : public std::false_type
 {
 };
 
 template <>
-struct isEntityType<Cell> : public std::true_type
+struct isNode<Node> : public std::true_type
 {
 };
 
 template <>
-struct isEntityType<const Cell> : public std::true_type
+struct isNode<const Node> : public std::true_type
 {
 };
 
-template <>
-struct isEntityType<Node> : public std::true_type
-{
-};
-
-template <>
-struct isEntityType<const Node> : public std::true_type
+template <class T>
+struct isFace : public std::false_type
 {
 };
 
 template <int Dir>
-struct isEntityType<Face<Dir>> : public std::true_type
+struct isFace<Face<Dir>> : public std::true_type
 {
 };
 
 template <int Dir>
-struct isEntityType<const Face<Dir>> : public std::true_type
+struct isFace<const Face<Dir>> : public std::true_type
+{
+};
+
+template <class T>
+struct isEdge : public std::false_type
 {
 };
 
 template <int Dir>
-struct isEntityType<Edge<Dir>> : public std::true_type
+struct isEdge<Edge<Dir>> : public std::true_type
 {
 };
 
 template <int Dir>
-struct isEntityType<const Edge<Dir>> : public std::true_type
+struct isEdge<const Edge<Dir>> : public std::true_type
 {
 };
 


### PR DESCRIPTION
This update is an improvement as we work towards an in-kernel API for P2G and G2P operations. A user now has an easier interface to project data to and from the grid in a kernel to allow for kernel fusion and to reduce the amount of code necessary to implement a P2G/G2P loop. The same differential operators are offered as before.

The global interpolation interface remains the same but now calls the new local interpolation kernels in the implementation.