### PR TITLE
Specialize HEFFTE CPU for HostSpace only

### DIFF
--- a/src/Cajita_FastFourierTransform.hpp
+++ b/src/Cajita_FastFourierTransform.hpp
@@ -43,8 +43,8 @@ struct HeffteMemoryTraits<Kokkos::CudaUVMSpace>
 };
 #endif
 
-template <class MemorySpace>
-struct HeffteMemoryTraits
+template <>
+struct HeffteMemoryTraits<Kokkos::HostSpace>
 {
     static constexpr heffte_memory_type_t value = HEFFTE_MEM_CPU;
 };


### PR DESCRIPTION
Previous strategy did not use explicit specialization which would have had a bad result in some situations by silently wanting host memory when perhaps device memory was intended. Suggested by @dalg24 in post-merge review of #20 