### PR TITLE
remove work array fromFFT setup

### DIFF
--- a/src/Cajita_FastFourierTransform.hpp
+++ b/src/Cajita_FastFourierTransform.hpp
@@ -214,8 +214,7 @@ class FastFourierTransform
         // Setup the fft.
         int permute = 0;
         int fftsize, sendsize, recvsize;
-        Scalar *work = nullptr;
-        _fft.setup( work, global_num_entity.data(), global_low.data(),
+        _fft.setup( global_num_entity.data(), global_low.data(),
                     global_high.data(), global_low.data(), global_high.data(),
                     permute, fftsize, sendsize, recvsize );
 


### PR DESCRIPTION
HEFFTE removed the work variable from its FFT setup functions: [HEFFTE commit  376fa0b](https://bitbucket.org/icl/heffte/commits/376fa0b9dcba)

This small change fixes a build issue and allows Cajita to build with the most recent HEFFTE. 