### PR TITLE
HEFFTE namespace update

### DIFF
--- a/src/Cajita_FastFourierTransform.hpp
+++ b/src/Cajita_FastFourierTransform.hpp
@@ -322,7 +322,7 @@ class FastFourierTransform
     }
 
   private:
-    HEFFTE_NS::FFT3d<Scalar> _fft;
+    HEFFTE::FFT3d<Scalar> _fft;
     Kokkos::View<Scalar *, DeviceType> _fft_work;
 };
 

--- a/unit_test/tstFastFourierTransform.hpp
+++ b/unit_test/tstFastFourierTransform.hpp
@@ -34,7 +34,7 @@ namespace Test
 void memoryTest()
 {
     auto mtype = HeffteMemoryTraits<TEST_MEMSPACE>::value;
-    HEFFTE_NS::Memory fft_mem;
+    HEFFTE::Memory fft_mem;
     fft_mem.memory_type = mtype;
     int size = 12;
     int nbytes = size * sizeof(double);


### PR DESCRIPTION
HEFFTE changed the name of their namespace from `HEFFTE_NS` to `HEFFTE` (see [heffte commit 4cad37f](https://bitbucket.org/icl/heffte/commits/4cad37f3c6cf07b204fa9d6cfb7566bf3b63450f))

This very small update reflects this change. 