### PR TITLE
fix cmake config for downstream packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 
 find_package(MPI REQUIRED)
 
-find_package(Kokkos REQUIRED)
+find_package(Kokkos 3 REQUIRED)
 
 find_package(HYPRE)
 if(HYPRE_FOUND)

--- a/cmake/CajitaConfig.cmake.in
+++ b/cmake/CajitaConfig.cmake.in
@@ -2,9 +2,10 @@
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR} ${CMAKE_MODULE_PATH})
 
-find_package(KOKKOS REQUIRED)
 find_package(MPI REQUIRED)
+find_package(Kokkos 3 REQUIRED)
 find_package(HYPRE)
+find_package(HEFFTE)
 
 include("${CMAKE_CURRENT_LIST_DIR}/CajitaTargets.cmake")
 check_required_components(Cajita)


### PR DESCRIPTION
The cmake config file was looking for the old Kokkos install files and was missing other dependencies.