### PR TITLE
Update HEFFTE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,8 @@ if(HYPRE_FOUND)
   set(CAJITA_HAVE_HYPRE ON)
 endif()
 
-find_package(HEFFTE)
-if(HEFFTE_FOUND)
+find_package(Heffte)
+if(Heffte_FOUND)
   set(CAJITA_HAVE_HEFFTE ON)
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,16 +50,8 @@ if(HYPRE_FOUND)
   target_link_libraries(Cajita HYPRE::hypre)
 endif()
 
-if(HEFFTE_FOUND)
-  if (TARGET HEFFTE::heffte)
-    target_link_libraries(Cajita HEFFTE::heffte)
-
-  endif()
-
-  if (HEFFTE::heffte_gpu)
-    target_link_libraries(Cajita HEFFTE::heffte_gpu)
-  endif()
-
+if(Heffte_FOUND)
+  target_link_libraries(Cajita Heffte::Heffte)
 endif()
 
 install(FILES ${HEADERS_PUBLIC}

--- a/src/Cajita_FastFourierTransform.hpp
+++ b/src/Cajita_FastFourierTransform.hpp
@@ -25,6 +25,8 @@
 
 namespace Cajita
 {
+namespace Experimental
+{
 //---------------------------------------------------------------------------//
 template <class MemorySpace>
 struct HeffteMemoryTraits;
@@ -341,6 +343,7 @@ createFastFourierTransform( const ArrayLayout<EntityType, MeshType> &layout,
 
 //---------------------------------------------------------------------------//
 
+} // end namespace Experimental
 } // end namespace Cajita
 
 #endif // end CAJITA_FASTFOURIERTRANSFORM_HPP

--- a/unit_test/tstFastFourierTransform.hpp
+++ b/unit_test/tstFastFourierTransform.hpp
@@ -33,7 +33,7 @@ namespace Test
 //---------------------------------------------------------------------------//
 void memoryTest()
 {
-    auto mtype = HeffteMemoryTraits<TEST_MEMSPACE>::value;
+    auto mtype = Experimental::HeffteMemoryTraits<TEST_MEMSPACE>::value;
     HEFFTE::Memory fft_mem;
     fft_mem.memory_type = mtype;
     int size = 12;
@@ -97,8 +97,8 @@ void forwardReverseTest()
     Kokkos::deep_copy( lhs_view, lhs_host_view );
 
     // Create an FFT
-    auto fft = createFastFourierTransform<double,TEST_DEVICE>(
-        *vector_layout, FastFourierTransformParams{}.setCollectiveType( 2 ).setExchangeType( 0 ).setPackType( 2 ).setScalingType( 1 ) );
+    auto fft = Experimental::createFastFourierTransform<double,TEST_DEVICE>(
+        *vector_layout, Experimental::FastFourierTransformParams{}.setCollectiveType( 2 ).setExchangeType( 0 ).setPackType( 2 ).setScalingType( 1 ) );
 
     // Forward transform
     fft->forward( *lhs );


### PR DESCRIPTION
This PR does a few things:

1. Puts HEFFTE/FFT code in the `Experimental` namespace to indicate the current stability concerns of HEFFTE as a dependency while we are on their `master`
2. Updates the HEFFTE package include structure for their new single-target model

After this we can move forward to attempting to use GPU FFTs and CPU FFTs in a single build.