### PR TITLE
Adding dimension-dependent cell sizes to uniform mesh

### DIFF
--- a/src/Cajita_BovWriter.hpp
+++ b/src/Cajita_BovWriter.hpp
@@ -266,13 +266,13 @@ void writeTimeStep( const int time_step_index, const double time,
         // Mesh global width
         header << "BRICK_SIZE: "
                << global_grid.globalNumEntity( Cell(), Dim::I ) *
-                      global_mesh.uniformCellSize( Dim::I )
+                      global_mesh.cellSize( Dim::I )
                << " "
                << global_grid.globalNumEntity( Cell(), Dim::J ) *
-                      global_mesh.uniformCellSize( Dim::J )
+                      global_mesh.cellSize( Dim::J )
                << " "
                << global_grid.globalNumEntity( Cell(), Dim::K ) *
-                      global_mesh.uniformCellSize( Dim::K )
+                      global_mesh.cellSize( Dim::K )
                << std::endl;
 
         // Number of data components. Scalar and vector types are

--- a/src/Cajita_BovWriter.hpp
+++ b/src/Cajita_BovWriter.hpp
@@ -266,13 +266,13 @@ void writeTimeStep( const int time_step_index, const double time,
         // Mesh global width
         header << "BRICK_SIZE: "
                << global_grid.globalNumEntity( Cell(), Dim::I ) *
-                      global_mesh.uniformCellSize()
+                      global_mesh.uniformCellSize( Dim::I )
                << " "
                << global_grid.globalNumEntity( Cell(), Dim::J ) *
-                      global_mesh.uniformCellSize()
+                      global_mesh.uniformCellSize( Dim::J )
                << " "
                << global_grid.globalNumEntity( Cell(), Dim::K ) *
-                      global_mesh.uniformCellSize()
+                      global_mesh.uniformCellSize( Dim::K )
                << std::endl;
 
         // Number of data components. Scalar and vector types are

--- a/src/Cajita_GlobalMesh.hpp
+++ b/src/Cajita_GlobalMesh.hpp
@@ -28,7 +28,9 @@ template <class MeshType>
 class GlobalMesh;
 
 //---------------------------------------------------------------------------//
-// Global mesh partial specialization for uniform mesh.
+// Global mesh partial specialization for uniform mesh. Uniform meshes are
+// rectilinear meshes where every cell in the mesh is identical. A cell is
+// described by its width in each dimension.
 template <class Scalar>
 class GlobalMesh<UniformMesh<Scalar>>
 {
@@ -39,7 +41,8 @@ class GlobalMesh<UniformMesh<Scalar>>
     // Scalar type.
     using scalar_type = Scalar;
 
-    // Cell size constructor - all cell dimensions are the same.
+    // Cell size constructor - special case where all cell dimensions are the
+    // same.
     GlobalMesh( const std::array<Scalar, 3> &global_low_corner,
                 const std::array<Scalar, 3> &global_high_corner,
                 const Scalar cell_size )
@@ -172,7 +175,10 @@ createUniformGlobalMesh( const std::array<Scalar, 3> &global_low_corner,
 }
 
 //---------------------------------------------------------------------------//
-// Global mesh partial specialization for non-uniform mesh.
+// Global mesh partial specialization for non-uniform mesh. Non-uniform meshes
+// have a list of node locations for each spatial dimension which describe a
+// rectilinear mesh that has arbitrary cell sizes - each cell can possibly be
+// different.
 template <class Scalar>
 class GlobalMesh<NonUniformMesh<Scalar>>
 {

--- a/src/Cajita_GlobalMesh.hpp
+++ b/src/Cajita_GlobalMesh.hpp
@@ -132,7 +132,7 @@ class GlobalMesh<UniformMesh<Scalar>>
     // UNIFORM MESH SPECIFIC
 
     // Get the uniform cell size in a given dimension.
-    Scalar uniformCellSize( const int dim ) const { return _cell_size[dim]; }
+    Scalar cellSize( const int dim ) const { return _cell_size[dim]; }
 
   private:
     std::array<Scalar, 3> _global_low_corner;

--- a/src/Cajita_LocalMesh.hpp
+++ b/src/Cajita_LocalMesh.hpp
@@ -49,7 +49,7 @@ class LocalMesh<Device, UniformMesh<Scalar>>
 
         // Get the cell size.
         for ( int d = 0; d < 3; ++d )
-            _cell_size[d] = global_mesh.uniformCellSize( d );
+            _cell_size[d] = global_mesh.cellSize( d );
 
         // Compute face area.
         _face_area[Dim::I] = _cell_size[Dim::J] * _cell_size[Dim::K];

--- a/unit_test/tstGlobalMesh.hpp
+++ b/unit_test/tstGlobalMesh.hpp
@@ -46,7 +46,8 @@ void uniformTest1()
     for ( int d = 0; d < 3; ++d )
         EXPECT_EQ( num_cell[d], global_mesh->globalNumCell(d) );
 
-    EXPECT_DOUBLE_EQ( global_mesh->uniformCellSize(), cell_size );
+    for ( int d = 0; d < 3; ++d )
+        EXPECT_DOUBLE_EQ( global_mesh->uniformCellSize(d), cell_size );
 }
 
 //---------------------------------------------------------------------------//
@@ -73,7 +74,36 @@ void uniformTest2()
         EXPECT_EQ( num_cell[d], global_mesh->globalNumCell(d) );
 
     double cell_size = 0.05;
-    EXPECT_DOUBLE_EQ( global_mesh->uniformCellSize(), cell_size );
+    for ( int d = 0; d < 3; ++d )
+        EXPECT_DOUBLE_EQ( global_mesh->uniformCellSize(d), cell_size );
+}
+
+//---------------------------------------------------------------------------//
+void uniformTest3()
+{
+    std::array<double,3> low_corner = { -1.2, 0.1, 1.1 };
+    std::array<double,3> high_corner = { -0.3, 9.5, 1.3 };
+    std::array<double,3> cell_size = {0.05,0.05,0.05};
+
+    auto global_mesh = createUniformGlobalMesh(
+        low_corner, high_corner, cell_size );
+
+    for ( int d = 0; d < 3; ++d )
+        EXPECT_DOUBLE_EQ( low_corner[d], global_mesh->lowCorner(d) );
+
+    for ( int d = 0; d < 3; ++d )
+        EXPECT_DOUBLE_EQ( high_corner[d], global_mesh->highCorner(d) );
+
+    for ( int d = 0; d < 3; ++d )
+        EXPECT_DOUBLE_EQ( high_corner[d] - low_corner[d],
+                          global_mesh->extent(d) );
+
+    std::array<int,3> num_cell = { 18, 188, 4 };
+    for ( int d = 0; d < 3; ++d )
+        EXPECT_EQ( num_cell[d], global_mesh->globalNumCell(d) );
+
+    for ( int d = 0; d < 3; ++d )
+        EXPECT_DOUBLE_EQ( global_mesh->uniformCellSize(d), cell_size[d] );
 }
 
 //---------------------------------------------------------------------------//
@@ -124,6 +154,7 @@ TEST( mesh, uniform_test )
 {
     uniformTest1();
     uniformTest2();
+    uniformTest3();
 }
 
 TEST( mesh, non_uniform_test )

--- a/unit_test/tstGlobalMesh.hpp
+++ b/unit_test/tstGlobalMesh.hpp
@@ -47,7 +47,7 @@ void uniformTest1()
         EXPECT_EQ( num_cell[d], global_mesh->globalNumCell(d) );
 
     for ( int d = 0; d < 3; ++d )
-        EXPECT_DOUBLE_EQ( global_mesh->uniformCellSize(d), cell_size );
+        EXPECT_DOUBLE_EQ( global_mesh->cellSize(d), cell_size );
 }
 
 //---------------------------------------------------------------------------//
@@ -75,7 +75,7 @@ void uniformTest2()
 
     double cell_size = 0.05;
     for ( int d = 0; d < 3; ++d )
-        EXPECT_DOUBLE_EQ( global_mesh->uniformCellSize(d), cell_size );
+        EXPECT_DOUBLE_EQ( global_mesh->cellSize(d), cell_size );
 }
 
 //---------------------------------------------------------------------------//
@@ -103,7 +103,7 @@ void uniformTest3()
         EXPECT_EQ( num_cell[d], global_mesh->globalNumCell(d) );
 
     for ( int d = 0; d < 3; ++d )
-        EXPECT_DOUBLE_EQ( global_mesh->uniformCellSize(d), cell_size[d] );
+        EXPECT_DOUBLE_EQ( global_mesh->cellSize(d), cell_size[d] );
 }
 
 //---------------------------------------------------------------------------//

--- a/unit_test/tstGlobalMesh.hpp
+++ b/unit_test/tstGlobalMesh.hpp
@@ -23,6 +23,7 @@ namespace Test
 {
 
 //---------------------------------------------------------------------------//
+// Test uniform mesh with cubic cells.
 void uniformTest1()
 {
     std::array<double,3> low_corner = { -1.2, 0.1, 1.1 };
@@ -51,6 +52,7 @@ void uniformTest1()
 }
 
 //---------------------------------------------------------------------------//
+// Test uniform mesh with number of cells constructor.
 void uniformTest2()
 {
     std::array<double,3> low_corner = { -1.2, 0.1, 1.1 };
@@ -79,6 +81,8 @@ void uniformTest2()
 }
 
 //---------------------------------------------------------------------------//
+// test uniform mesh with cells that can have a different size in each
+// dimension
 void uniformTest3()
 {
     std::array<double,3> low_corner = { -1.2, 0.1, 1.1 };
@@ -107,6 +111,7 @@ void uniformTest3()
 }
 
 //---------------------------------------------------------------------------//
+// test a non uniform mesh
 void nonUniformTest()
 {
     std::vector<float> i_edge = { -0.3, 0.4, 1.1 };


### PR DESCRIPTION
Uniform meshes can technically have different cell sizes in each dimension and still be uniform. The PR adds this feature including allowing for different dimensions in the spline interpolation. The single-dimension cubic cell constructor is still preserved.

Fixes #40 