### PR TITLE
Scatter Reduce Types

### DIFF
--- a/src/Cajita_LocalGrid.hpp
+++ b/src/Cajita_LocalGrid.hpp
@@ -112,7 +112,7 @@ class LocalGrid
        the local grid. The default behavior is to use the halo width of the
        local grid.
 
-       Interface same structure as:
+       Interface has the same structure as:
 
        template<class DecompositionTag, class EntityType, class IndexType>
        IndexSpace<3> sharedIndexSpace( DecompositionTag, EntityType,

--- a/unit_test/tstHalo.hpp
+++ b/unit_test/tstHalo.hpp
@@ -15,6 +15,7 @@
 #include <Cajita_GlobalGrid.hpp>
 #include <Cajita_Array.hpp>
 #include <Cajita_ManualPartitioner.hpp>
+#include <Cajita_UniformDimPartitioner.hpp>
 
 #include <Kokkos_Core.hpp>
 
@@ -142,6 +143,162 @@ void gatherScatterTest( const ManualPartitioner& partitioner,
 }
 
 //---------------------------------------------------------------------------//
+void scatterMinTest()
+{
+    // Create the global grid.
+    double cell_size = 0.23;
+    std::array<int,3> global_num_cell = { 32, 23, 41 };
+    std::array<double,3> global_low_corner = { 1.2, 3.3, -2.8 };
+    std::array<double,3> global_high_corner =
+        { global_low_corner[0] + cell_size * global_num_cell[0],
+          global_low_corner[1] + cell_size * global_num_cell[1],
+          global_low_corner[2] + cell_size * global_num_cell[2] };
+    auto global_mesh = createUniformGlobalMesh( global_low_corner,
+                                                global_high_corner,
+                                                global_num_cell );
+
+    // Create the global grid.
+    std::array<bool,3> is_dim_periodic = {true,true,true};
+    auto global_grid = createGlobalGrid( MPI_COMM_WORLD,
+                                         global_mesh,
+                                         is_dim_periodic,
+                                         Cajita::UniformDimPartitioner() );
+
+    // Create an array on the cells.
+    unsigned array_halo_width = 2;
+    int dofs_per_cell = 4;
+    auto cell_layout =
+        createArrayLayout( global_grid, array_halo_width, dofs_per_cell, Cell() );
+    auto array = createArray<double,TEST_DEVICE>( "array", cell_layout );
+
+    // Assign the rank to the array.
+    int comm_rank;
+    MPI_Comm_rank( MPI_COMM_WORLD, &comm_rank );
+    ArrayOp::assign( *array, comm_rank, Ghost() );
+
+    // Create a halo pattern - just write to your 8 corner neighbors so we can
+    // eliminate overlap between neighbors and not need to resolve the
+    // collision.
+    HaloPattern pattern;
+    std::vector<std::array<int,3>> neighbors =
+        { {-1,-1,-1}, {1,-1,-1}, {-1,1,-1}, {1,1,-1},
+          {-1,-1,1}, {1,-1,1}, {-1,1,1}, {1,1,1} };
+    pattern.setNeighbors( neighbors );
+
+    // Create a halo.
+    auto halo = createHalo( *array, pattern );
+
+    // Scatter.
+    halo->scatter( *array, ScatterReduce::Min() );
+
+    // Check the reduction.
+    auto host_array = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), array->view() );
+    for ( const auto& n : neighbors )
+    {
+        auto neighbor_rank =
+            cell_layout->localGrid()->neighborRank(n[0],n[1],n[2]);
+        auto shared_space =
+            cell_layout->localGrid()->sharedIndexSpace(
+                Cajita::Own(), Cajita::Cell(), n[0], n[1], n[2] );
+        for ( int i = shared_space.min(Dim::I);
+              i < shared_space.max(Dim::I);
+              ++i )
+            for ( int j = shared_space.min(Dim::J);
+                  j < shared_space.max(Dim::J);
+                  ++j )
+                for ( int k = shared_space.min(Dim::K);
+                      k < shared_space.max(Dim::K);
+                      ++k )
+                    for ( int l = 0; l < 4; ++l )
+                    {
+                        if ( neighbor_rank < comm_rank )
+                            EXPECT_EQ( host_array(i,j,k,l), neighbor_rank );
+                        else
+                            EXPECT_EQ( host_array(i,j,k,l), comm_rank );
+                    }
+    }
+}
+
+//---------------------------------------------------------------------------//
+void scatterMaxTest()
+{
+    // Create the global grid.
+    double cell_size = 0.23;
+    std::array<int,3> global_num_cell = { 32, 23, 41 };
+    std::array<double,3> global_low_corner = { 1.2, 3.3, -2.8 };
+    std::array<double,3> global_high_corner =
+        { global_low_corner[0] + cell_size * global_num_cell[0],
+          global_low_corner[1] + cell_size * global_num_cell[1],
+          global_low_corner[2] + cell_size * global_num_cell[2] };
+    auto global_mesh = createUniformGlobalMesh( global_low_corner,
+                                                global_high_corner,
+                                                global_num_cell );
+
+    // Create the global grid.
+    std::array<bool,3> is_dim_periodic = {true,true,true};
+    auto global_grid = createGlobalGrid( MPI_COMM_WORLD,
+                                         global_mesh,
+                                         is_dim_periodic,
+                                         Cajita::UniformDimPartitioner() );
+
+    // Create an array on the cells.
+    unsigned array_halo_width = 2;
+    int dofs_per_cell = 4;
+    auto cell_layout =
+        createArrayLayout( global_grid, array_halo_width, dofs_per_cell, Cell() );
+    auto array = createArray<double,TEST_DEVICE>( "array", cell_layout );
+
+    // Assign the rank to the array.
+    int comm_rank;
+    MPI_Comm_rank( MPI_COMM_WORLD, &comm_rank );
+    ArrayOp::assign( *array, comm_rank, Ghost() );
+
+    // Create a halo pattern - just write to your 8 corner neighbors so we can
+    // eliminate overlap between neighbors and not need to resolve the
+    // collision.
+    HaloPattern pattern;
+    std::vector<std::array<int,3>> neighbors =
+        { {-1,-1,-1}, {1,-1,-1}, {-1,1,-1}, {1,1,-1},
+          {-1,-1,1}, {1,-1,1}, {-1,1,1}, {1,1,1} };
+    pattern.setNeighbors( neighbors );
+
+    // Create a halo.
+    auto halo = createHalo( *array, pattern );
+
+    // Scatter.
+    halo->scatter( *array, ScatterReduce::Max() );
+
+    // Check the reduction.
+    auto host_array = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), array->view() );
+    for ( const auto& n : neighbors )
+    {
+        auto neighbor_rank =
+            cell_layout->localGrid()->neighborRank(n[0],n[1],n[2]);
+        auto shared_space =
+            cell_layout->localGrid()->sharedIndexSpace(
+                Cajita::Own(), Cajita::Cell(), n[0], n[1], n[2] );
+        for ( int i = shared_space.min(Dim::I);
+              i < shared_space.max(Dim::I);
+              ++i )
+            for ( int j = shared_space.min(Dim::J);
+                  j < shared_space.max(Dim::J);
+                  ++j )
+                for ( int k = shared_space.min(Dim::K);
+                      k < shared_space.max(Dim::K);
+                      ++k )
+                    for ( int l = 0; l < 4; ++l )
+                    {
+                        if ( neighbor_rank > comm_rank )
+                            EXPECT_EQ( host_array(i,j,k,l), neighbor_rank );
+                        else
+                            EXPECT_EQ( host_array(i,j,k,l), comm_rank );
+                    }
+    }
+}
+
+//---------------------------------------------------------------------------//
 // RUN TESTS
 //---------------------------------------------------------------------------//
 TEST( TEST_CATEGORY, not_periodic_test )
@@ -201,6 +358,13 @@ TEST( TEST_CATEGORY, periodic_test )
     std::swap( ranks_per_dim[0], ranks_per_dim[1] );
     partitioner = ManualPartitioner( ranks_per_dim );
     gatherScatterTest( partitioner, is_dim_periodic );
+}
+
+//---------------------------------------------------------------------------//
+TEST( TEST_CATEGORY, scatter_reduce_test )
+{
+    scatterMinTest();
+    scatterMaxTest();
 }
 
 //---------------------------------------------------------------------------//

--- a/unit_test/tstHalo.hpp
+++ b/unit_test/tstHalo.hpp
@@ -299,6 +299,81 @@ void scatterMaxTest()
 }
 
 //---------------------------------------------------------------------------//
+void scatterReplaceTest()
+{
+    // Create the global grid.
+    double cell_size = 0.23;
+    std::array<int,3> global_num_cell = { 32, 23, 41 };
+    std::array<double,3> global_low_corner = { 1.2, 3.3, -2.8 };
+    std::array<double,3> global_high_corner =
+        { global_low_corner[0] + cell_size * global_num_cell[0],
+          global_low_corner[1] + cell_size * global_num_cell[1],
+          global_low_corner[2] + cell_size * global_num_cell[2] };
+    auto global_mesh = createUniformGlobalMesh( global_low_corner,
+                                                global_high_corner,
+                                                global_num_cell );
+
+    // Create the global grid.
+    std::array<bool,3> is_dim_periodic = {true,true,true};
+    auto global_grid = createGlobalGrid( MPI_COMM_WORLD,
+                                         global_mesh,
+                                         is_dim_periodic,
+                                         Cajita::UniformDimPartitioner() );
+
+    // Create an array on the cells.
+    unsigned array_halo_width = 2;
+    int dofs_per_cell = 4;
+    auto cell_layout =
+        createArrayLayout( global_grid, array_halo_width, dofs_per_cell, Cell() );
+    auto array = createArray<double,TEST_DEVICE>( "array", cell_layout );
+
+    // Assign the rank to the array.
+    int comm_rank;
+    MPI_Comm_rank( MPI_COMM_WORLD, &comm_rank );
+    ArrayOp::assign( *array, comm_rank, Ghost() );
+
+    // Create a halo pattern - just write to your 8 corner neighbors so we can
+    // eliminate overlap between neighbors and not need to resolve the
+    // collision.
+    HaloPattern pattern;
+    std::vector<std::array<int,3>> neighbors =
+        { {-1,-1,-1}, {1,-1,-1}, {-1,1,-1}, {1,1,-1},
+          {-1,-1,1}, {1,-1,1}, {-1,1,1}, {1,1,1} };
+    pattern.setNeighbors( neighbors );
+
+    // Create a halo.
+    auto halo = createHalo( *array, pattern );
+
+    // Scatter.
+    halo->scatter( *array, ScatterReduce::Replace() );
+
+    // Check the reduction.
+    auto host_array = Kokkos::create_mirror_view_and_copy(
+        Kokkos::HostSpace(), array->view() );
+    for ( const auto& n : neighbors )
+    {
+        auto neighbor_rank =
+            cell_layout->localGrid()->neighborRank(n[0],n[1],n[2]);
+        auto shared_space =
+            cell_layout->localGrid()->sharedIndexSpace(
+                Cajita::Own(), Cajita::Cell(), n[0], n[1], n[2] );
+        for ( int i = shared_space.min(Dim::I);
+              i < shared_space.max(Dim::I);
+              ++i )
+            for ( int j = shared_space.min(Dim::J);
+                  j < shared_space.max(Dim::J);
+                  ++j )
+                for ( int k = shared_space.min(Dim::K);
+                      k < shared_space.max(Dim::K);
+                      ++k )
+                    for ( int l = 0; l < 4; ++l )
+                    {
+                        EXPECT_EQ( host_array(i,j,k,l), neighbor_rank );
+                    }
+    }
+}
+
+//---------------------------------------------------------------------------//
 // RUN TESTS
 //---------------------------------------------------------------------------//
 TEST( TEST_CATEGORY, not_periodic_test )
@@ -365,6 +440,7 @@ TEST( TEST_CATEGORY, scatter_reduce_test )
 {
     scatterMinTest();
     scatterMaxTest();
+    scatterReplaceTest();
 }
 
 //---------------------------------------------------------------------------//


### PR DESCRIPTION
Adds additional reduction types to the halo scatter operation. Users can now sum, min, and max when resolving collisions in the local scatter reduction operation. The max operation, for example, is useful in level set redistancing algorithms needed by some ECP apps. The default sum interface is still intact.