### PR TITLE
case change Heffte

### DIFF
--- a/cmake/CajitaConfig.cmake.in
+++ b/cmake/CajitaConfig.cmake.in
@@ -5,7 +5,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR} ${CMAKE_MODULE_PATH})
 find_package(MPI REQUIRED)
 find_package(Kokkos 3 REQUIRED)
 find_package(HYPRE)
-find_package(HEFFTE)
+find_package(Heffte)
 
 include("${CMAKE_CURRENT_LIST_DIR}/CajitaTargets.cmake")
 check_required_components(Cajita)


### PR DESCRIPTION
CMake config fix for case change in Heffte package.

@streeve and I also thought it might be nice to add the `QUIET` keyword like so:
`find_package(HYPRE QUIET)`

if only because when building CabanaMD with a `find_package(Cajita)` , it gives a warning that HYPRE was not found. @junghans may have thoughts on doing that?